### PR TITLE
fix: ecosystem audit — migrate config to pydantic-settings

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [workspace]
-name = "ProjectTelemachy"
+name = "project-telemachy"
 version = "0.1.0"
 description = "Declarative workflow engine for ai-maestro multi-agent workflows"
 channels = ["conda-forge"]
@@ -9,13 +9,13 @@ platforms = ["linux-64"]
 python = ">=3.10"
 
 [pypi-dependencies]
-pydantic       = ">=2.0"
-httpx          = ">=0.27"
-nats-py        = ">=2.0"
-pyyaml         = ">=6.0"
-rich           = ">=13.0"
-typer          = ">=0.12"
-python-dotenv  = ">=1.0"
+pydantic          = ">=2.0"
+pydantic-settings = ">=2.0"
+httpx             = ">=0.27"
+nats-py           = ">=2.0"
+pyyaml            = ">=6.0"
+rich              = ">=13.0"
+typer             = ">=0.12"
 
 [tasks]
 run    = "just run"

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -2,24 +2,21 @@
 
 from __future__ import annotations
 
-import os
-
-from dotenv import load_dotenv
-
-load_dotenv()
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings:
+class Settings(BaseSettings):
     """Application settings for ProjectTelemachy, loaded from env / .env file."""
 
-    maestro_url: str
-    maestro_api_key: str
-    nats_url: str
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+    )
 
-    def __init__(self) -> None:
-        self.maestro_url = os.environ.get("MAESTRO_URL", "http://172.20.0.1:23000")
-        self.maestro_api_key = os.environ.get("MAESTRO_API_KEY", "")
-        self.nats_url = os.environ.get("NATS_URL", "nats://localhost:4222")
+    maestro_url: str = "http://172.20.0.1:23000"
+    maestro_api_key: str = ""
+    nats_url: str = "nats://localhost:4222"
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- **I8**: Migrate config.py from `os.environ.get` + `python-dotenv` to `pydantic_settings.BaseSettings`
- Replace `python-dotenv` with `pydantic-settings` in pixi.toml
- **M2**: Standardize workspace name from `ProjectTelemachy` to `project-telemachy`

## Test plan
- [x] `just test` — 24/24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)