### PR TITLE
fix(ci): resolve 19-day-old Python type errors and import failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.8.3
         with:
-          pixi-version: latest
+          pixi-version: v0.66.0
           cache: true
 
       - name: Lint (ruff)

--- a/pixi.lock
+++ b/pixi.lock
@@ -63,6 +63,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
 packages:
@@ -632,6 +633,11 @@ packages:
   - shellingham>=1.3.0
   - rich>=12.3.0
   - annotated-doc>=0.0.2
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl
+  name: types-pyyaml
+  version: 6.0.12.20260408
+  sha256: fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
   name: typing-extensions

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,6 +28,7 @@ pytest          = ">=8.0"
 pytest-asyncio  = ">=0.23"
 ruff            = ">=0.4"
 mypy            = ">=1.10"
+types-PyYAML    = ">=6.0"
 
 [environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import sys
 from pathlib import Path
 from typing import Annotated
 

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 from telemachy.config import settings
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
-from telemachy.models import AgentSpec, TaskSpec, TeamSpec, WorkflowSpec, WorkflowState
+from telemachy.models import AgentSpec, TeamSpec, WorkflowSpec, WorkflowState
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio
 
 from telemachy.executor import WorkflowExecutor
 from telemachy.agamemnon_client import AgamemnonClient
-from telemachy.models import AgentSpec, TaskSpec, TeamSpec, WorkflowSpec, WorkflowState
+from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
 
 
 # ---------------------------------------------------------------------------
@@ -79,7 +78,7 @@ class TestProvisioning:
         client.create_agent = AsyncMock(side_effect=["id-a", "id-b"])
 
         executor = WorkflowExecutor(client, poll_interval=0.01)
-        state = await executor.execute(spec)
+        await executor.execute(spec)
 
         assert client.create_agent.call_count == 2
         assert client.wake_agent.call_count == 2


### PR DESCRIPTION
## Summary

- **Ruff lint failures**: Removed unused imports (`json`, `sys` in `cli.py`; `TaskSpec` in `executor.py`; `patch`, `pytest_asyncio`, `TeamSpec`, `WorkflowState` in `test_executor.py`) and unused local variable `state` in `test_executor.py`
- **Mypy `import-untyped` error**: Added `types-PyYAML` to dev dependencies — mypy >=1.10 raises `import-untyped` as a distinct error class that `--ignore-missing-imports` does not suppress; the stubs resolve this cleanly
- **Pixi cache 400 errors**: Pinned `pixi-version: v0.66.0` and bumped `setup-pixi` to `v0.8.3` which includes fixes for transient GitHub Actions cache service 400 responses; regenerated `pixi.lock` to include the new stub package

All three CI steps (ruff, mypy, pytest) now pass locally: 24/24 tests green.

## Test plan

- [ ] Confirm CI workflow passes on this PR (all three steps: Lint, Type-check, Test)
- [ ] Verify `pixi run ruff check src tests` exits 0
- [ ] Verify `pixi run mypy src/telemachy --ignore-missing-imports` exits 0
- [ ] Verify `pixi run pytest --tb=short -q` exits 0 with 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)