### PR TITLE
chore(ruff): add ruff configuration to pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,18 @@ packages = ["src/telemachy"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["telemachy"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
Add `[tool.ruff]` configuration section to `pyproject.toml` for consistent linting and formatting rules. Selects E, F, I (isort), UP (pyupgrade), B (bugbear), SIM rules.

Closes #50
