### PR TITLE
feat: add __all__ exports to telemachy package __init__.py

### DIFF
--- a/src/telemachy/__init__.py
+++ b/src/telemachy/__init__.py
@@ -1,3 +1,20 @@
 """ProjectTelemachy — declarative workflow engine for ProjectAgamemnon."""
 
+from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
+from telemachy.config import Settings
+from telemachy.executor import WorkflowExecutor
+from telemachy.models import AgentSpec, TaskSpec, TeamSpec, WorkflowSpec, WorkflowState
+
 version = "0.1.0"
+
+__all__ = [
+    "WorkflowExecutor",
+    "AgamemnonClient",
+    "AgamemnonError",
+    "WorkflowSpec",
+    "AgentSpec",
+    "TeamSpec",
+    "TaskSpec",
+    "WorkflowState",
+    "Settings",
+]


### PR DESCRIPTION
## Summary

Add `__all__` to `src/telemachy/__init__.py` to define a clean public API surface. Also adds top-level imports so `from telemachy import WorkflowExecutor` works without knowing internal module structure.

Closes #53
