### PR TITLE
feat(models): add validators for apiVersion, metadata.name, duplicate subjects, per-team assign_to, extra=forbid

### DIFF
--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 
 class AgentSpec(BaseModel):
     """Specification for a single Agamemnon agent to provision."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     program: str = "claude-code"
@@ -31,6 +33,8 @@ class AgentSpec(BaseModel):
 class TaskSpec(BaseModel):
     """Specification for a single task within a team."""
 
+    model_config = ConfigDict(extra="forbid")
+
     subject: str
     description: str
     assign_to: str  # agent name
@@ -39,6 +43,8 @@ class TaskSpec(BaseModel):
 
 class TeamSpec(BaseModel):
     """Specification for a team of agents and their tasks."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     agents: list[str]  # agent names — must match names in WorkflowSpec.agents
@@ -92,6 +98,8 @@ class TeamSpec(BaseModel):
 
 class WorkflowSpec(BaseModel):
     """Top-level workflow specification parsed from a workflow YAML file."""
+
+    model_config = ConfigDict(extra="forbid")
 
     apiVersion: str = "telemachy/v1"
     metadata: dict[str, str]

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -60,6 +60,15 @@ class TeamSpec(BaseModel):
                 )
         return tasks
 
+    @model_validator(mode="after")
+    def validate_unique_task_subjects(self) -> "TeamSpec":
+        subjects = [t.subject for t in self.tasks]
+        seen: set[str] = set()
+        dupes = [s for s in subjects if s in seen or seen.add(s)]  # type: ignore[func-returns-value]
+        if dupes:
+            raise ValueError(f"Duplicate task subjects in team {self.name!r}: {dupes}")
+        return self
+
     def detect_dependency_cycles(self) -> None:
         """Raise ValueError if task dependencies contain a cycle."""
         task_subjects = {t.subject for t in self.tasks}

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -107,6 +107,13 @@ class WorkflowSpec(BaseModel):
     teams: list[TeamSpec]
     teardown: Literal["on_completion", "on_failure", "never"] = "on_completion"
 
+    @field_validator("apiVersion")
+    @classmethod
+    def validate_api_version(cls, v: str) -> str:
+        if v not in {"telemachy/v1"}:
+            raise ValueError(f"Unknown apiVersion {v!r}. Expected 'telemachy/v1'.")
+        return v
+
     @model_validator(mode="after")
     def validate_references(self) -> "WorkflowSpec":
         agent_names = {a.name for a in self.agents}

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -69,6 +69,17 @@ class TeamSpec(BaseModel):
             raise ValueError(f"Duplicate task subjects in team {self.name!r}: {dupes}")
         return self
 
+    @model_validator(mode="after")
+    def validate_task_assignments(self) -> "TeamSpec":
+        for task in self.tasks:
+            if task.assign_to not in self.agents:
+                raise ValueError(
+                    f"Task {task.subject!r} assigns to agent {task.assign_to!r} "
+                    f"which is not in team {self.name!r}. "
+                    f"Team agents: {self.agents}"
+                )
+        return self
+
     def detect_dependency_cycles(self) -> None:
         """Raise ValueError if task dependencies contain a cycle."""
         task_subjects = {t.subject for t in self.tasks}

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -115,6 +115,12 @@ class WorkflowSpec(BaseModel):
         return v
 
     @model_validator(mode="after")
+    def validate_metadata_name(self) -> "WorkflowSpec":
+        if "name" not in self.metadata or not self.metadata["name"]:
+            raise ValueError("workflow metadata must contain a non-empty 'name' key")
+        return self
+
+    @model_validator(mode="after")
     def validate_references(self) -> "WorkflowSpec":
         agent_names = {a.name for a in self.agents}
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,7 +104,7 @@ class TestWorkflowSpecParsing:
     def test_unknown_assign_to_raises(self) -> None:
         raw = yaml.safe_load(MINIMAL_WORKFLOW_YAML)
         raw["teams"][0]["tasks"][0]["assign_to"] = "ghost"
-        with pytest.raises(Exception, match="unknown agent"):
+        with pytest.raises(Exception, match="not in team"):
             WorkflowSpec.model_validate(raw)
 
     def test_teardown_default_is_on_completion(self) -> None:


### PR DESCRIPTION
Bundle five models.py validation improvements:
- Add `extra="forbid"` to all Pydantic models to catch YAML typos
- Validate `apiVersion` rejects unknown values
- Require `name` key in workflow metadata
- Detect duplicate task subjects within a team
- Validate `assign_to` references an agent within the same team (not just globally)

Closes #14
Closes #19
Closes #20
Closes #21
Closes #51
