### PR TITLE
feat(client): defensive parsing, retry/backoff, configurable hostId, TLS enforcement, fix assigneeAgentId

### DIFF
--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -35,8 +35,9 @@ def _require(data: dict[str, Any], *keys: str, context: str = "") -> Any:
 class AgamemnonClient:
     """Async client for ProjectAgamemnon REST API endpoints used by Telemachy."""
 
-    def __init__(self, url: str, api_key: str = "") -> None:
+    def __init__(self, url: str, api_key: str = "", host_id: str = "hermes") -> None:
         self._base_url = url.rstrip("/")
+        self._host_id = host_id
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -113,7 +114,7 @@ class AgamemnonClient:
     async def _create_docker_agent(self, spec: AgentSpec) -> str:
         payload: dict[str, object] = {
             "name": spec.name,
-            "hostId": "hermes",
+            "hostId": self._host_id,
             "image": spec.docker_image,
             "cpus": spec.cpus,
             "memory": spec.memory,

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -69,6 +70,23 @@ class AgamemnonClient:
                 detail = response.text
             raise AgamemnonError(response.status_code, detail)
 
+    async def _request_with_retry(
+        self, method: str, url: str, *, max_attempts: int = 3, **kwargs: Any
+    ) -> httpx.Response:
+        """Issue an HTTP request, retrying on server errors and transient failures."""
+        last_exc: Exception | None = None
+        for attempt in range(max_attempts):
+            try:
+                resp = await self._http.request(method, url, **kwargs)
+                if resp.status_code < 500:
+                    return resp
+                last_exc = AgamemnonError(resp.status_code, f"Server error {resp.status_code}")
+            except (httpx.ConnectError, httpx.TimeoutException) as e:
+                last_exc = e
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(2**attempt)
+        raise AgamemnonError(0, f"Request failed after {max_attempts} attempts: {last_exc}")
+
     # === Agent endpoints ===
 
     async def create_agent(self, spec: AgentSpec) -> str:
@@ -88,7 +106,7 @@ class AgamemnonClient:
         if spec.model:
             payload["programArgs"] = f"--model {spec.model}"
 
-        response = await self._http.post("/v1/agents", json=payload)
+        response = await self._request_with_retry("POST", "/v1/agents", json=payload)
         self._raise_for_status(response)
         return str(_require(response.json(), "agent", "id", context="create_agent"))
 
@@ -102,28 +120,28 @@ class AgamemnonClient:
             "workingDirectory": spec.working_dir,
         }
 
-        response = await self._http.post("/v1/agents/docker", json=payload)
+        response = await self._request_with_retry("POST", "/v1/agents/docker", json=payload)
         self._raise_for_status(response)
         return str(_require(response.json(), "agent", "id", context="create_docker_agent"))
 
     async def wake_agent(self, agent_id: str) -> None:
         """Start a stopped agent."""
-        response = await self._http.post(f"/v1/agents/{agent_id}/start")
+        response = await self._request_with_retry("POST", f"/v1/agents/{agent_id}/start")
         self._raise_for_status(response)
 
     async def hibernate_agent(self, agent_id: str) -> None:
         """Stop a running agent."""
-        response = await self._http.post(f"/v1/agents/{agent_id}/stop")
+        response = await self._request_with_retry("POST", f"/v1/agents/{agent_id}/stop")
         self._raise_for_status(response)
 
     async def delete_agent(self, agent_id: str) -> None:
         """Permanently delete an agent."""
-        response = await self._http.delete(f"/v1/agents/{agent_id}")
+        response = await self._request_with_retry("DELETE", f"/v1/agents/{agent_id}")
         self._raise_for_status(response)
 
     async def list_agents(self) -> list[dict[str, object]]:
         """List all agents."""
-        response = await self._http.get("/v1/agents")
+        response = await self._request_with_retry("GET", "/v1/agents")
         self._raise_for_status(response)
         return response.json().get("agents", [])  # type: ignore[return-value]
 
@@ -131,19 +149,19 @@ class AgamemnonClient:
 
     async def create_team(self, name: str, agent_ids: list[str]) -> str:
         """Create a team, then set members. Returns the Agamemnon team id."""
-        response = await self._http.post("/v1/teams", json={"name": name})
+        response = await self._request_with_retry("POST", "/v1/teams", json={"name": name})
         self._raise_for_status(response)
         team_id = str(_require(response.json(), "team", "id", context="create_team"))
         if agent_ids:
-            r2 = await self._http.put(
-                f"/v1/teams/{team_id}", json={"agentIds": agent_ids}
+            r2 = await self._request_with_retry(
+                "PUT", f"/v1/teams/{team_id}", json={"agentIds": agent_ids}
             )
             self._raise_for_status(r2)
         return team_id
 
     async def delete_team(self, team_id: str) -> None:
         """Delete a team."""
-        response = await self._http.delete(f"/v1/teams/{team_id}")
+        response = await self._request_with_retry("DELETE", f"/v1/teams/{team_id}")
         self._raise_for_status(response)
 
     # === Task endpoints ===
@@ -161,7 +179,9 @@ class AgamemnonClient:
         if blocked_by_ids:
             payload["blockedBy"] = blocked_by_ids
 
-        response = await self._http.post(f"/v1/teams/{team_id}/tasks", json=payload)
+        response = await self._request_with_retry(
+            "POST", f"/v1/teams/{team_id}/tasks", json=payload
+        )
         self._raise_for_status(response)
         return str(_require(response.json(), "task", "id", context="create_task"))
 
@@ -179,14 +199,14 @@ class AgamemnonClient:
         if assignee_agent_id is not None:
             payload["assigneeAgentId"] = assignee_agent_id
 
-        response = await self._http.put(
-            f"/v1/teams/{team_id}/tasks/{task_id}", json=payload
+        response = await self._request_with_retry(
+            "PUT", f"/v1/teams/{team_id}/tasks/{task_id}", json=payload
         )
         self._raise_for_status(response)
         return response.json()  # type: ignore[return-value]
 
     async def get_tasks(self, team_id: str) -> list[dict[str, object]]:
         """List all tasks for a team."""
-        response = await self._http.get(f"/v1/teams/{team_id}/tasks")
+        response = await self._request_with_retry("GET", f"/v1/teams/{team_id}/tasks")
         self._raise_for_status(response)
         return _require(response.json(), "tasks", context="get_tasks")  # type: ignore[return-value]

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -35,7 +35,27 @@ def _require(data: dict[str, Any], *keys: str, context: str = "") -> Any:
 class AgamemnonClient:
     """Async client for ProjectAgamemnon REST API endpoints used by Telemachy."""
 
-    def __init__(self, url: str, api_key: str = "", host_id: str = "hermes") -> None:
+    def __init__(
+        self,
+        url: str,
+        api_key: str = "",
+        host_id: str = "hermes",
+        require_tls: bool = False,
+        nats_url: str = "",
+    ) -> None:
+        if require_tls:
+            if not url.startswith("https://"):
+                raise AgamemnonError(
+                    0,
+                    "TLS required (REQUIRE_TLS=true) but AGAMEMNON_URL uses plain HTTP. "
+                    "Use https:// or set REQUIRE_TLS=false.",
+                )
+            if nats_url and not nats_url.startswith("tls://"):
+                raise AgamemnonError(
+                    0,
+                    "TLS required (REQUIRE_TLS=true) but NATS_URL uses plain nats://. "
+                    "Use tls:// or set REQUIRE_TLS=false.",
+                )
         self._base_url = url.rstrip("/")
         self._host_id = host_id
         headers: dict[str, str] = {"Content-Type": "application/json"}
@@ -168,14 +188,29 @@ class AgamemnonClient:
     # === Task endpoints ===
 
     async def create_task(
-        self, team_id: str, spec: TaskSpec, blocked_by_ids: list[str] | None = None
+        self,
+        team_id: str,
+        spec: TaskSpec,
+        blocked_by_ids: list[str] | None = None,
+        assignee_agent_id: str | None = None,
     ) -> str:
-        """Create a task within a team. Returns the Agamemnon task id."""
+        """Create a task within a team. Returns the Agamemnon task id.
+
+        Args:
+            team_id: The Agamemnon team ID.
+            spec: The task specification.
+            blocked_by_ids: Optional list of Agamemnon task IDs this task is blocked by.
+            assignee_agent_id: Resolved Agamemnon agent ID to assign the task to.
+                If provided, takes precedence over spec.assign_to (which is a name).
+        """
         payload: dict[str, object] = {
             "subject": spec.subject,
             "description": spec.description,
         }
-        if spec.assign_to:
+        if assignee_agent_id is not None:
+            payload["assigneeAgentId"] = assignee_agent_id
+        elif spec.assign_to:
+            # Fallback: spec.assign_to should be an ID, not a name — callers must resolve
             payload["assigneeAgentId"] = spec.assign_to
         if blocked_by_ids:
             payload["blockedBy"] = blocked_by_ids

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 
 from telemachy.models import AgentSpec, TaskSpec
@@ -13,6 +15,20 @@ class AgamemnonError(Exception):
     def __init__(self, status_code: int, message: str) -> None:
         self.status_code = status_code
         super().__init__(f"Agamemnon API error {status_code}: {message}")
+
+
+def _require(data: dict[str, Any], *keys: str, context: str = "") -> Any:
+    """Safely traverse nested dict keys, raising AgamemnonError on missing keys."""
+    val: Any = data
+    for k in keys:
+        if not isinstance(val, dict) or k not in val:
+            ctx = f" in {context}" if context else ""
+            raise AgamemnonError(
+                0,
+                f"Unexpected API response shape{ctx}: missing key {k!r}. Got: {val!r}",
+            )
+        val = val[k]
+    return val
 
 
 class AgamemnonClient:
@@ -74,8 +90,7 @@ class AgamemnonClient:
 
         response = await self._http.post("/v1/agents", json=payload)
         self._raise_for_status(response)
-        data = response.json()
-        return str(data.get("agent", data)["id"])
+        return str(_require(response.json(), "agent", "id", context="create_agent"))
 
     async def _create_docker_agent(self, spec: AgentSpec) -> str:
         payload: dict[str, object] = {
@@ -89,8 +104,7 @@ class AgamemnonClient:
 
         response = await self._http.post("/v1/agents/docker", json=payload)
         self._raise_for_status(response)
-        data = response.json()
-        return str(data.get("agent", data)["id"])
+        return str(_require(response.json(), "agent", "id", context="create_docker_agent"))
 
     async def wake_agent(self, agent_id: str) -> None:
         """Start a stopped agent."""
@@ -119,7 +133,7 @@ class AgamemnonClient:
         """Create a team, then set members. Returns the Agamemnon team id."""
         response = await self._http.post("/v1/teams", json={"name": name})
         self._raise_for_status(response)
-        team_id = str(response.json()["team"]["id"])
+        team_id = str(_require(response.json(), "team", "id", context="create_team"))
         if agent_ids:
             r2 = await self._http.put(
                 f"/v1/teams/{team_id}", json={"agentIds": agent_ids}
@@ -149,7 +163,7 @@ class AgamemnonClient:
 
         response = await self._http.post(f"/v1/teams/{team_id}/tasks", json=payload)
         self._raise_for_status(response)
-        return str(response.json()["task"]["id"])
+        return str(_require(response.json(), "task", "id", context="create_task"))
 
     async def update_task(
         self,
@@ -175,4 +189,4 @@ class AgamemnonClient:
         """List all tasks for a team."""
         response = await self._http.get(f"/v1/teams/{team_id}/tasks")
         self._raise_for_status(response)
-        return response.json()["tasks"]  # type: ignore[return-value]
+        return _require(response.json(), "tasks", context="get_tasks")  # type: ignore[return-value]

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     agamemnon_api_key: str = ""
     nats_url: str = "nats://localhost:4222"
     workflows_dir: Path = Path("workflows")
+    host_id: str = "hermes"
 
 
 settings = Settings()

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     nats_url: str = "nats://localhost:4222"
     workflows_dir: Path = Path("workflows")
     host_id: str = "hermes"
+    require_tls: bool = False
 
 
 settings = Settings()

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -142,7 +142,13 @@ class WorkflowExecutor:
 
             for task_spec in ready:
                 blocked_by_ids = [submitted[dep] for dep in task_spec.blocked_by if dep in submitted]
-                task_id = await self._client.create_task(team_id, task_spec, blocked_by_ids)
+                # Resolve agent name → Agamemnon agent ID before submitting (#12)
+                resolved_agent_id: str | None = None
+                if task_spec.assign_to:
+                    resolved_agent_id = agent_ids.get(task_spec.assign_to)
+                task_id = await self._client.create_task(
+                    team_id, task_spec, blocked_by_ids, assignee_agent_id=resolved_agent_id
+                )
                 submitted[task_spec.subject] = task_id
                 logger.info(
                     "Submitted task '%s' → id=%s", task_spec.subject, task_id
@@ -218,6 +224,9 @@ async def run_workflow(spec: WorkflowSpec) -> WorkflowState:
     async with AgamemnonClient(
         url=settings.agamemnon_url,
         api_key=settings.agamemnon_api_key,
+        host_id=settings.host_id,
+        require_tls=settings.require_tls,
+        nats_url=settings.nats_url,
     ) as client:
         executor = WorkflowExecutor(client)
         return await executor.execute(spec)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -154,7 +154,12 @@ class TestTaskCreation:
         """Task with blocked_by must not be submitted before its dependency completes."""
         call_order: list[str] = []
 
-        async def fake_create_task(team_id: str, spec: TaskSpec, blocked_by_ids: list[str] | None = None) -> str:
+        async def fake_create_task(
+            team_id: str,
+            spec: TaskSpec,
+            blocked_by_ids: list[str] | None = None,
+            assignee_agent_id: str | None = None,
+        ) -> str:
             call_order.append(spec.subject)
             return f"task-{len(call_order)}"
 


### PR DESCRIPTION
Bundle five AgamemnonClient improvements:
- Defensive response parsing catches unexpected API shapes
- Retry/backoff logic for transient HTTP failures (up to 3 attempts, exponential backoff)
- Docker agent `hostId` configurable via `HOST_ID` env var (was hardcoded to "hermes")
- `REQUIRE_TLS=true` enforces HTTPS/TLS for Agamemnon and NATS URLs
- Fix `create_task` to use resolved agent ID instead of agent name for `assigneeAgentId`

Closes #11
Closes #12
Closes #23
Closes #24
Closes #34
