### PR TITLE
feat(executor): 11 improvements — timeout, teardown, retry, logging, dry-run, hooks, rich progress

### DIFF
--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from pathlib import Path
 from typing import Annotated
@@ -24,6 +25,18 @@ app = typer.Typer(
 )
 console = Console()
 err_console = Console(stderr=True)
+
+logger = logging.getLogger(__name__)
+
+
+def _setup_logging() -> None:
+    """Configure logging from settings (LOG_LEVEL env var, default INFO)."""
+    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
 
 _SHELL_METACHARACTERS: re.Pattern[str] = re.compile(r"[;&|$`><(){}\[\]!?*~\\]")
 
@@ -193,6 +206,7 @@ def cancel(
 
 
 def main() -> None:
+    _setup_logging()
     app()
 
 

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -15,7 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from telemachy.config import settings
-from telemachy.executor import run_workflow
+from telemachy.executor import WorkflowExecutor, run_workflow
 from telemachy.models import WorkflowSpec
 
 app = typer.Typer(
@@ -118,14 +118,17 @@ def _print_plan(spec: WorkflowSpec) -> None:
 @app.command()
 def run(
     workflow_path: Annotated[Path, typer.Argument(help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)")],
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Print plan without executing")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run/--no-dry-run", help="Simulate execution without calling Agamemnon")] = False,
 ) -> None:
     """Execute a workflow YAML file."""
     _validate_workflow_path(workflow_path)
     spec = _load_workflow(workflow_path)
 
     if dry_run:
+        console.print(f"[bold yellow][dry-run][/bold yellow] Simulating workflow: {spec.name}")
         _print_plan(spec)
+        state = asyncio.run(run_workflow(spec, dry_run=True))
+        console.print(f"[bold yellow][dry-run][/bold yellow] Simulation complete. id={state.workflow_id}")
         return
 
     console.print(f"[bold green]Running workflow:[/bold green] {spec.name}")

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -13,6 +13,7 @@ import typer
 import yaml
 from rich.console import Console
 from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from telemachy.agamemnon_client import AgamemnonClient
@@ -135,8 +136,12 @@ def run(
 
     console.print(f"[bold green]Running workflow:[/bold green] {spec.name}")
 
+    # Count total tasks across all teams for the progress display
+    total_tasks = sum(len(team.tasks) for team in spec.teams)
+
     async def _run_with_signals() -> None:
         stop_event = asyncio.Event()
+        completed_count = 0
 
         def _handle_signal(sig: int, _frame: object) -> None:
             logger.warning("Received signal %s, initiating graceful shutdown...", sig)
@@ -145,15 +150,41 @@ def run(
         signal.signal(signal.SIGINT, _handle_signal)
         signal.signal(signal.SIGTERM, _handle_signal)
 
-        async with AgamemnonClient(
-            url=settings.agamemnon_url,
-            api_key=settings.agamemnon_api_key,
-            host_id=settings.host_id,
-            require_tls=settings.require_tls,
-            nats_url=settings.nats_url,
-        ) as client:
-            executor = WorkflowExecutor(client, stop_event=stop_event)
-            result = await executor.execute(spec)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            task_id = progress.add_task(
+                f"Running workflow: {spec.name}  [Completed: 0/{total_tasks}]",
+                total=None,
+            )
+
+            def _on_task_complete(**kwargs: object) -> None:
+                nonlocal completed_count
+                completed_count += 1
+                task_info = kwargs.get("task", {})
+                subject = task_info.get("subject", "?") if isinstance(task_info, dict) else "?"  # type: ignore[union-attr]
+                progress.update(
+                    task_id,
+                    description=(
+                        f"Running workflow: {spec.name}  "
+                        f"[Completed: {completed_count}/{total_tasks}]  "
+                        f"last: {subject}"
+                    ),
+                )
+
+            async with AgamemnonClient(
+                url=settings.agamemnon_url,
+                api_key=settings.agamemnon_api_key,
+                host_id=settings.host_id,
+                require_tls=settings.require_tls,
+                nats_url=settings.nats_url,
+            ) as client:
+                executor = WorkflowExecutor(client, stop_event=stop_event)
+                executor.add_hook("on_task_complete", _on_task_complete)
+                result = await executor.execute(spec)
 
         if result.status == "completed":
             console.print(f"[bold green]Workflow completed.[/bold green] id={result.workflow_id}")

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import signal
 from pathlib import Path
 from typing import Annotated
 
@@ -14,6 +15,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from telemachy.agamemnon_client import AgamemnonClient
 from telemachy.config import settings
 from telemachy.executor import WorkflowExecutor, run_workflow
 from telemachy.models import WorkflowSpec
@@ -133,17 +135,37 @@ def run(
 
     console.print(f"[bold green]Running workflow:[/bold green] {spec.name}")
 
-    state = asyncio.run(run_workflow(spec))
+    async def _run_with_signals() -> None:
+        stop_event = asyncio.Event()
 
-    if state.status == "completed":
-        console.print(f"[bold green]Workflow completed.[/bold green] id={state.workflow_id}")
-    else:
-        console.print(
-            f"[bold red]Workflow {state.status}.[/bold red] "
-            f"id={state.workflow_id}"
-            + (f"  error={state.error}" if state.error else "")
-        )
-        raise typer.Exit(1)
+        def _handle_signal(sig: int, _frame: object) -> None:
+            logger.warning("Received signal %s, initiating graceful shutdown...", sig)
+            stop_event.set()
+
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        async with AgamemnonClient(
+            url=settings.agamemnon_url,
+            api_key=settings.agamemnon_api_key,
+            host_id=settings.host_id,
+            require_tls=settings.require_tls,
+            nats_url=settings.nats_url,
+        ) as client:
+            executor = WorkflowExecutor(client, stop_event=stop_event)
+            result = await executor.execute(spec)
+
+        if result.status == "completed":
+            console.print(f"[bold green]Workflow completed.[/bold green] id={result.workflow_id}")
+        else:
+            console.print(
+                f"[bold red]Workflow {result.status}.[/bold red] "
+                f"id={result.workflow_id}"
+                + (f"  error={result.error}" if result.error else "")
+            )
+            raise typer.Exit(1)
+
+    asyncio.run(_run_with_signals())
 
 
 @app.command()

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     require_tls: bool = False
     monitor_timeout_seconds: float = 3600.0
     monitor_max_polls: int = 7200
+    log_level: str = "INFO"
 
 
 settings = Settings()

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     monitor_timeout_seconds: float = 3600.0
     monitor_max_polls: int = 7200
     log_level: str = "INFO"
+    default_workflow_timeout: float = 7200.0
 
 
 settings = Settings()

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     workflows_dir: Path = Path("workflows")
     host_id: str = "hermes"
     require_tls: bool = False
+    monitor_timeout_seconds: float = 3600.0
+    monitor_max_polls: int = 7200
 
 
 settings = Settings()

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -106,18 +106,27 @@ class WorkflowExecutor:
         teams: list[TeamSpec],
         agent_ids: dict[str, str],
     ) -> dict[str, str]:
-        """Create all teams and submit tasks respecting dependencies. Returns {team_name: team_id}."""
-        team_id_map: dict[str, str] = {}
+        """Create all teams concurrently and submit tasks respecting dependencies.
 
-        for team_spec in teams:
-            member_ids = [agent_ids[name] for name in team_spec.agents]
-            team_id = await self._client.create_team(team_spec.name, member_ids)
-            team_id_map[team_spec.name] = team_id
-            logger.info("Created team '%s' → id=%s", team_spec.name, team_id)
+        Teams are provisioned in parallel via asyncio.gather (see #55).
+        Returns {team_name: team_id}.
+        """
+        results: list[tuple[str, str]] = await asyncio.gather(
+            *[self._create_team(team_spec, agent_ids) for team_spec in teams]
+        )
+        return dict(results)
 
-            await self._submit_tasks_with_deps(team_id, team_spec, agent_ids)
-
-        return team_id_map
+    async def _create_team(
+        self,
+        team_spec: TeamSpec,
+        agent_ids: dict[str, str],
+    ) -> tuple[str, str]:
+        """Create a single team, submit its tasks, and return (team_name, team_id)."""
+        member_ids = [agent_ids[name] for name in team_spec.agents]
+        team_id = await self._client.create_team(team_spec.name, member_ids)
+        logger.info("Created team '%s' → id=%s", team_spec.name, team_id)
+        await self._submit_tasks_with_deps(team_id, team_spec, agent_ids)
+        return team_spec.name, team_id
 
     async def _submit_tasks_with_deps(
         self,

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -36,6 +36,16 @@ class WorkflowExecutor:
 
     async def execute(self, spec: WorkflowSpec) -> WorkflowState:
         """Run a full workflow: provision → assign tasks → monitor → teardown."""
+        timeout = spec.timeout_seconds if spec.timeout_seconds is not None else settings.default_workflow_timeout
+        try:
+            return await asyncio.wait_for(self._run(spec), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise WorkflowTimeoutError(
+                f"Workflow '{spec.name}' exceeded its execution timeout of {timeout}s"
+            )
+
+    async def _run(self, spec: WorkflowSpec) -> WorkflowState:
+        """Internal execution body — wrapped by execute() with a timeout."""
         workflow_id = str(uuid.uuid4())[:8]
         state = WorkflowState(
             workflow_id=workflow_id,

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -14,7 +14,8 @@ from telemachy.models import AgentSpec, TeamSpec, WorkflowSpec, WorkflowState
 logger = logging.getLogger(__name__)
 
 # Terminal task statuses reported by ProjectAgamemnon
-_DONE_STATUSES = {"completed", "backlog", "failed", "error", "cancelled"}
+# NOTE: "backlog" is an initial/queued state, NOT a terminal state — do not include it here.
+_DONE_STATUSES = {"completed", "failed", "error", "cancelled"}
 
 
 class WorkflowExecutor:

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -206,6 +206,13 @@ class WorkflowExecutor:
 
         logger.info("Running teardown for workflow '%s'...", state.spec.name)
 
+        for name, team_id in state.created_teams.items():
+            try:
+                await self._client.delete_team(team_id)
+                logger.debug("Deleted team '%s' (id=%s)", name, team_id)
+            except AgamemnonError as exc:
+                logger.warning("Failed to delete team '%s': %s", name, exc)
+
         for name, agent_id in state.created_agents.items():
             try:
                 await self._client.delete_agent(agent_id)

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -16,6 +17,10 @@ logger = logging.getLogger(__name__)
 # Terminal task statuses reported by ProjectAgamemnon
 # NOTE: "backlog" is an initial/queued state, NOT a terminal state — do not include it here.
 _DONE_STATUSES = {"completed", "failed", "error", "cancelled"}
+
+
+class WorkflowTimeoutError(Exception):
+    """Raised when workflow monitoring exceeds the configured timeout or max poll count."""
 
 
 class WorkflowExecutor:
@@ -162,7 +167,24 @@ class WorkflowExecutor:
         """Poll all team tasks until every task reaches a terminal status."""
         logger.info("Monitoring workflow '%s' for completion...", state.spec.name)
 
+        poll_count = 0
+        start_time = time.monotonic()
+        timeout = settings.monitor_timeout_seconds
+        max_polls = settings.monitor_max_polls
+
         while True:
+            elapsed = time.monotonic() - start_time
+            if elapsed > timeout:
+                raise WorkflowTimeoutError(
+                    f"Monitoring timed out after {elapsed:.1f}s "
+                    f"(limit: {timeout}s) for workflow '{state.spec.name}'"
+                )
+            if poll_count > max_polls:
+                raise WorkflowTimeoutError(
+                    f"Monitoring exceeded max poll count {max_polls} "
+                    f"for workflow '{state.spec.name}'"
+                )
+
             all_done = True
             any_failed = False
 
@@ -185,6 +207,7 @@ class WorkflowExecutor:
                     raise RuntimeError("One or more tasks failed during workflow execution")
                 return
 
+            poll_count += 1
             await asyncio.sleep(self._poll_interval)
 
     # === Teardown ===

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -33,10 +33,12 @@ class WorkflowExecutor:
         client: AgamemnonClient,
         poll_interval: float = 5.0,
         dry_run: bool = False,
+        stop_event: asyncio.Event | None = None,
     ) -> None:
         self._client = client
         self._poll_interval = poll_interval
         self._dry_run = dry_run
+        self._stop_event = stop_event
         self._hooks: dict[str, list[Callable[..., Any]]] = {
             "on_task_complete": [],
             "on_task_failed": [],
@@ -227,6 +229,9 @@ class WorkflowExecutor:
             if not ready:
                 if not pending:
                     break
+                if self._stop_event and self._stop_event.is_set():
+                    logger.warning("Stop event set — aborting task submission")
+                    raise asyncio.CancelledError("Task submission cancelled by stop event")
                 # Wait for some tasks to complete before continuing
                 await asyncio.sleep(self._poll_interval)
                 tasks_status = await self._client.get_tasks(team_id)
@@ -267,6 +272,10 @@ class WorkflowExecutor:
         max_polls = settings.monitor_max_polls
 
         while True:
+            if self._stop_event and self._stop_event.is_set():
+                logger.warning("Stop event set — aborting monitoring for workflow '%s'", state.spec.name)
+                raise asyncio.CancelledError("Workflow cancelled by stop event")
+
             elapsed = time.monotonic() - start_time
             if elapsed > timeout:
                 raise WorkflowTimeoutError(
@@ -358,7 +367,11 @@ def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-async def run_workflow(spec: WorkflowSpec, dry_run: bool = False) -> WorkflowState:
+async def run_workflow(
+    spec: WorkflowSpec,
+    dry_run: bool = False,
+    stop_event: asyncio.Event | None = None,
+) -> WorkflowState:
     """Convenience function: create a client from settings and execute a workflow."""
     async with AgamemnonClient(
         url=settings.agamemnon_url,
@@ -367,5 +380,5 @@ async def run_workflow(spec: WorkflowSpec, dry_run: bool = False) -> WorkflowSta
         require_tls=settings.require_tls,
         nats_url=settings.nats_url,
     ) as client:
-        executor = WorkflowExecutor(client, dry_run=dry_run)
+        executor = WorkflowExecutor(client, dry_run=dry_run, stop_event=stop_event)
         return await executor.execute(spec)

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -6,7 +6,9 @@ import asyncio
 import logging
 import time
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
+from typing import Any
 
 from telemachy.config import settings
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
@@ -33,6 +35,33 @@ class WorkflowExecutor:
     ) -> None:
         self._client = client
         self._poll_interval = poll_interval
+        self._hooks: dict[str, list[Callable[..., Any]]] = {
+            "on_task_complete": [],
+            "on_task_failed": [],
+            "on_workflow_complete": [],
+            "on_workflow_failed": [],
+        }
+
+    def add_hook(self, event: str, callback: Callable[..., Any]) -> None:
+        """Register a callback for a workflow execution event.
+
+        Supported events: on_task_complete, on_task_failed,
+        on_workflow_complete, on_workflow_failed.
+        """
+        if event not in self._hooks:
+            raise ValueError(
+                f"Unknown hook event {event!r}. "
+                f"Valid events: {sorted(self._hooks)}"
+            )
+        self._hooks[event].append(callback)
+
+    async def _emit(self, event: str, **kwargs: Any) -> None:
+        """Fire all callbacks registered for *event*."""
+        for cb in self._hooks.get(event, []):
+            if asyncio.iscoroutinefunction(cb):
+                await cb(**kwargs)
+            else:
+                cb(**kwargs)
 
     async def execute(self, spec: WorkflowSpec) -> WorkflowState:
         """Run a full workflow: provision → assign tasks → monitor → teardown."""
@@ -72,6 +101,7 @@ class WorkflowExecutor:
             state.status = "completed"
             state.completed_at = _now()
             logger.info("Workflow '%s' completed successfully", spec.name)
+            await self._emit("on_workflow_complete", state=state)
 
         except asyncio.CancelledError:
             state.status = "cancelled"
@@ -84,6 +114,7 @@ class WorkflowExecutor:
             state.completed_at = _now()
             state.error = str(exc)
             logger.error("Workflow '%s' failed: %s", spec.name, exc)
+            await self._emit("on_workflow_failed", state=state, error=exc)
 
         finally:
             await self._teardown(state)
@@ -230,20 +261,30 @@ class WorkflowExecutor:
 
             all_done = True
             any_failed = False
+            # Track which tasks already emitted events to avoid duplicate callbacks
+            emitted_done: set[str] = getattr(self, "_emitted_task_events", set())
+            self._emitted_task_events: set[str] = emitted_done  # type: ignore[attr-defined]
 
             for team_name, team_id in state.created_teams.items():
                 tasks = await self._client.get_tasks(team_id)
                 for task in tasks:
                     status = str(task.get("status", ""))
+                    task_subject = str(task.get("subject", ""))
                     if status not in _DONE_STATUSES:
                         all_done = False
                     if status in {"failed", "error"}:
                         any_failed = True
                         logger.warning(
                             "Task '%s' in team '%s' failed",
-                            task.get("subject"),
+                            task_subject,
                             team_name,
                         )
+                        if task_subject not in emitted_done:
+                            emitted_done.add(task_subject)
+                            await self._emit("on_task_failed", task=task, team=team_name)
+                    elif status == "completed" and task_subject not in emitted_done:
+                        emitted_done.add(task_subject)
+                        await self._emit("on_task_complete", task=task, team=team_name)
 
             if all_done:
                 if any_failed:

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -32,9 +32,11 @@ class WorkflowExecutor:
         self,
         client: AgamemnonClient,
         poll_interval: float = 5.0,
+        dry_run: bool = False,
     ) -> None:
         self._client = client
         self._poll_interval = poll_interval
+        self._dry_run = dry_run
         self._hooks: dict[str, list[Callable[..., Any]]] = {
             "on_task_complete": [],
             "on_task_failed": [],
@@ -95,8 +97,11 @@ class WorkflowExecutor:
                 spec.teams, state.created_agents
             )
 
-            # Monitor until all tasks reach a terminal state
-            await self._monitor_completion(state)
+            # Monitor until all tasks reach a terminal state (skipped in dry-run)
+            if not self._dry_run:
+                await self._monitor_completion(state)
+            else:
+                logger.info("[dry-run] Skipping monitoring — no real tasks submitted")
 
             state.status = "completed"
             state.completed_at = _now()
@@ -134,6 +139,10 @@ class WorkflowExecutor:
 
     async def _provision_one_agent(self, spec: AgentSpec) -> tuple[str, str]:
         """Create a single agent and wake it. Returns (name, agamemnon_id)."""
+        if self._dry_run:
+            dry_id = f"dry-run-agent-{spec.name}"
+            logger.info("[dry-run] Would create agent '%s' → id=%s", spec.name, dry_id)
+            return spec.name, dry_id
         agent_id = await self._client.create_agent(spec)
         logger.debug("Created agent '%s' → id=%s", spec.name, agent_id)
         await self._client.wake_agent(agent_id)
@@ -163,6 +172,17 @@ class WorkflowExecutor:
         agent_ids: dict[str, str],
     ) -> tuple[str, str]:
         """Create a single team, submit its tasks, and return (team_name, team_id)."""
+        if self._dry_run:
+            dry_id = f"dry-run-team-{team_spec.name}"
+            logger.info("[dry-run] Would create team '%s' → id=%s", team_spec.name, dry_id)
+            for task_spec in team_spec.tasks:
+                logger.info(
+                    "[dry-run] Would submit task '%s' (assign_to=%s, blocked_by=%s)",
+                    task_spec.subject,
+                    task_spec.assign_to,
+                    task_spec.blocked_by,
+                )
+            return team_spec.name, dry_id
         member_ids = [agent_ids[name] for name in team_spec.agents]
         team_id = await self._client.create_team(team_spec.name, member_ids)
         logger.info("Created team '%s' → id=%s", team_spec.name, team_id)
@@ -298,6 +318,10 @@ class WorkflowExecutor:
 
     async def _teardown(self, state: WorkflowState) -> None:
         """Delete agents and teams based on the workflow's teardown policy."""
+        if self._dry_run:
+            logger.info("[dry-run] Skipping teardown")
+            return
+
         policy = state.spec.teardown
 
         should_teardown = (
@@ -334,7 +358,7 @@ def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-async def run_workflow(spec: WorkflowSpec) -> WorkflowState:
+async def run_workflow(spec: WorkflowSpec, dry_run: bool = False) -> WorkflowState:
     """Convenience function: create a client from settings and execute a workflow."""
     async with AgamemnonClient(
         url=settings.agamemnon_url,
@@ -343,5 +367,5 @@ async def run_workflow(spec: WorkflowSpec) -> WorkflowState:
         require_tls=settings.require_tls,
         nats_url=settings.nats_url,
     ) as client:
-        executor = WorkflowExecutor(client)
+        executor = WorkflowExecutor(client, dry_run=dry_run)
         return await executor.execute(spec)

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -125,25 +125,49 @@ class WorkflowExecutor:
         team_spec: TeamSpec,
         agent_ids: dict[str, str],
     ) -> None:
-        """Submit tasks in dependency order, waiting for predecessors to finish."""
+        """Submit tasks in dependency order, waiting for predecessors to finish.
+
+        If a dependency has failed/errored/cancelled, the dependent task is skipped
+        rather than waiting forever (prevents infinite loop — see #13).
+        """
         submitted: dict[str, str] = {}   # subject → task_id
         completed_subjects: set[str] = set()
+        failed_subjects: set[str] = set()
+        skipped_subjects: set[str] = set()
         pending = list(team_spec.tasks)
 
         while pending:
+            # Skip tasks whose dependencies have failed
+            newly_skipped = [
+                t for t in pending
+                if any(dep in failed_subjects or dep in skipped_subjects for dep in t.blocked_by)
+            ]
+            for task_spec in newly_skipped:
+                logger.warning(
+                    "Skipping task '%s': one or more dependencies failed or were skipped",
+                    task_spec.subject,
+                )
+                skipped_subjects.add(task_spec.subject)
+                pending.remove(task_spec)
+
             ready = [
                 t for t in pending
                 if all(dep in completed_subjects for dep in t.blocked_by)
             ]
             if not ready:
+                if not pending:
+                    break
                 # Wait for some tasks to complete before continuing
                 await asyncio.sleep(self._poll_interval)
                 tasks_status = await self._client.get_tasks(team_id)
                 for task_status in tasks_status:
                     subject = str(task_status.get("subject", ""))
                     status = str(task_status.get("status", ""))
-                    if status == "completed" and subject in submitted:
-                        completed_subjects.add(subject)
+                    if subject in submitted:
+                        if status == "completed":
+                            completed_subjects.add(subject)
+                        elif status in {"failed", "error", "cancelled"}:
+                            failed_subjects.add(subject)
                 continue
 
             for task_spec in ready:

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -126,6 +126,7 @@ class WorkflowSpec(BaseModel):
     agents: list[AgentSpec]
     teams: list[TeamSpec]
     teardown: Literal["on_completion", "on_failure", "never"] = "on_completion"
+    timeout_seconds: float | None = None  # workflow-level execution timeout (#56)
 
     @field_validator("apiVersion")
     @classmethod


### PR DESCRIPTION
Bundle 11 executor improvements into a single PR to avoid file conflicts:

- Remove `backlog` from `_DONE_STATUSES` (initial state, not terminal)
- Add team deletion to teardown
- Add timeout and max poll count to `_monitor_completion`
- Skip tasks whose dependencies failed (prevents infinite loop)
- Provision teams concurrently with `asyncio.gather`
- Structured logging with configurable `LOG_LEVEL` env var
- Workflow-level execution timeout (`timeout_seconds` in YAML + `DEFAULT_WORKFLOW_TIMEOUT` env var)
- Workflow execution event hooks (`on_task_complete`, `on_workflow_complete`, etc.)
- Dry-run mode (`--dry-run` CLI flag + `WorkflowExecutor(dry_run=True)`)
- Graceful shutdown on SIGINT/SIGTERM
- Rich progress display for workflow execution

Closes #2
Closes #5
Closes #7
Closes #13
Closes #36
Closes #46
Closes #55
Closes #56
Closes #57
Closes #58
Closes #62
