### PR TITLE
test(client): add AgamemnonClient HTTP interaction tests

### DIFF
--- a/tests/test_agamemnon_client.py
+++ b/tests/test_agamemnon_client.py
@@ -1,0 +1,174 @@
+"""Tests for AgamemnonClient HTTP interactions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
+from telemachy.models import AgentSpec
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status_code: int, body: object) -> MagicMock:
+    """Return a mock httpx.Response-like object."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.is_error = status_code >= 400
+    resp.json.return_value = body
+    resp.text = str(body)
+    return resp
+
+
+def _local_agent_spec(name: str = "worker") -> AgentSpec:
+    return AgentSpec(name=name, runtime="local")
+
+
+async def _enter_client(url: str = "http://localhost:8080", **kwargs: object) -> AgamemnonClient:
+    """Return an AgamemnonClient that has been entered as async context manager."""
+    client = AgamemnonClient(url=url, **kwargs)  # type: ignore[arg-type]
+    # Manually install a real-ish AsyncClient so _http property works
+    import httpx
+    client._client = httpx.AsyncClient(base_url=url)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# TEST 1 — create_agent returns agent ID on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_agent_returns_agent_id() -> None:
+    client = await _enter_client()
+    ok_resp = _make_response(201, {"agent": {"id": "agent-123"}})
+
+    with patch.object(client._client, "request", new_callable=AsyncMock, return_value=ok_resp):
+        agent_id = await client.create_agent(_local_agent_spec())
+
+    assert agent_id == "agent-123"
+
+
+# ---------------------------------------------------------------------------
+# TEST 2 — create_agent raises AgamemnonError on 4xx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_agent_raises_on_4xx() -> None:
+    client = await _enter_client()
+    err_resp = _make_response(400, {"detail": "bad request"})
+    err_resp.json.return_value = {"detail": "bad request"}
+
+    with patch.object(client._client, "request", new_callable=AsyncMock, return_value=err_resp):
+        with pytest.raises(AgamemnonError) as exc_info:
+            await client.create_agent(_local_agent_spec())
+
+    assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# TEST 3 — create_agent raises AgamemnonError on malformed response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_agent_raises_on_malformed_response() -> None:
+    """Response missing 'agent.id' key should raise AgamemnonError."""
+    client = await _enter_client()
+    # Response is 201 OK but body has unexpected shape
+    bad_resp = _make_response(201, {"result": "ok"})
+
+    with patch.object(client._client, "request", new_callable=AsyncMock, return_value=bad_resp):
+        with pytest.raises(AgamemnonError) as exc_info:
+            await client.create_agent(_local_agent_spec())
+
+    # Error should reference the missing key
+    assert "agent" in str(exc_info.value).lower() or exc_info.value.status_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TEST 4 — retry on 503: two failures then success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_agent_retries_on_503() -> None:
+    client = await _enter_client()
+    fail_resp = _make_response(503, {"detail": "service unavailable"})
+    ok_resp = _make_response(201, {"agent": {"id": "retry-id"}})
+
+    # 503, 503, then 201
+    mock_request = AsyncMock(side_effect=[fail_resp, fail_resp, ok_resp])
+
+    with patch.object(client._client, "request", mock_request):
+        # Patch asyncio.sleep so the test doesn't actually wait
+        with patch("telemachy.agamemnon_client.asyncio.sleep", new_callable=AsyncMock):
+            agent_id = await client.create_agent(_local_agent_spec())
+
+    assert agent_id == "retry-id"
+    assert mock_request.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# TEST 5 — start_agent calls correct endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_agent_calls_correct_endpoint() -> None:
+    client = await _enter_client()
+    ok_resp = _make_response(200, {})
+    ok_resp.is_error = False
+
+    mock_request = AsyncMock(return_value=ok_resp)
+    with patch.object(client._client, "request", mock_request):
+        await client.wake_agent("agent-123")
+
+    mock_request.assert_called_once()
+    call_args = mock_request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1/agents/agent-123/start" in call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# TEST 6 — delete_agent calls correct endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_calls_correct_endpoint() -> None:
+    client = await _enter_client()
+    ok_resp = _make_response(204, {})
+    ok_resp.is_error = False
+
+    mock_request = AsyncMock(return_value=ok_resp)
+    with patch.object(client._client, "request", mock_request):
+        await client.delete_agent("agent-123")
+
+    mock_request.assert_called_once()
+    call_args = mock_request.call_args
+    assert call_args[0][0] == "DELETE"
+    assert "/v1/agents/agent-123" in call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# TEST 7 — TLS enforcement raises on http:// when require_tls=True
+# ---------------------------------------------------------------------------
+
+
+def test_tls_enforcement_raises_on_http_url() -> None:
+    """AgamemnonClient with require_tls=True and http:// URL must raise AgamemnonError."""
+    with pytest.raises(AgamemnonError) as exc_info:
+        AgamemnonClient(
+            url="http://localhost:8080",
+            require_tls=True,
+        )
+
+    assert exc_info.value.status_code == 0
+    assert "TLS" in str(exc_info.value) or "https" in str(exc_info.value).lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,197 @@
+"""Tests for the Telemachy CLI using typer.testing.CliRunner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from telemachy.cli import app
+from telemachy.models import WorkflowSpec
+
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_WORKFLOW_YAML = """\
+apiVersion: telemachy/v1
+metadata:
+  name: test-workflow
+  description: A minimal test workflow
+agents:
+  - name: worker
+    runtime: local
+teams:
+  - name: team-a
+    agents: [worker]
+    tasks:
+      - subject: Task 1
+        description: Do some work
+        assign_to: worker
+teardown: on_completion
+"""
+
+_INVALID_WORKFLOW_YAML_MISSING_NAME = """\
+apiVersion: telemachy/v1
+metadata:
+  description: Missing the name field
+agents:
+  - name: worker
+    runtime: local
+teams:
+  - name: team-a
+    agents: [worker]
+    tasks:
+      - subject: Task 1
+        description: Do some work
+        assign_to: worker
+teardown: on_completion
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def valid_workflow_file(tmp_path: Path) -> Path:
+    """Write a minimal valid workflow YAML to a tmp file."""
+    p = tmp_path / "workflow.yaml"
+    p.write_text(_VALID_WORKFLOW_YAML)
+    return p
+
+
+@pytest.fixture()
+def invalid_workflow_file(tmp_path: Path) -> Path:
+    """Write a workflow YAML missing metadata.name to a tmp file."""
+    p = tmp_path / "invalid_workflow.yaml"
+    p.write_text(_INVALID_WORKFLOW_YAML_MISSING_NAME)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# TEST 1 — validate command with valid YAML
+# ---------------------------------------------------------------------------
+
+
+def test_validate_valid_yaml(valid_workflow_file: Path) -> None:
+    """validate command exits 0 and prints 'valid' for a correct YAML."""
+    result = runner.invoke(app, ["validate", str(valid_workflow_file)])
+    assert result.exit_code == 0, f"Unexpected exit code. Output:\n{result.output}"
+    assert "valid" in result.output.lower(), (
+        f"Expected 'valid' in output but got:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TEST 2 — validate command with invalid YAML (missing name)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_invalid_yaml_missing_name(invalid_workflow_file: Path) -> None:
+    """validate command should fail or print an error for a YAML missing metadata.name."""
+    result = runner.invoke(app, ["validate", str(invalid_workflow_file)])
+    # Either non-zero exit code or error output
+    has_error_output = (
+        "error" in result.output.lower()
+        or "invalid" in result.output.lower()
+        or "validation" in result.output.lower()
+    )
+    assert result.exit_code != 0 or has_error_output, (
+        f"Expected failure or error message, got exit_code={result.exit_code} "
+        f"output:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TEST 3 — validate command with non-existent file
+# ---------------------------------------------------------------------------
+
+
+def test_validate_nonexistent_file(tmp_path: Path) -> None:
+    """validate command should fail for a file that does not exist."""
+    missing = tmp_path / "does_not_exist.yaml"
+    result = runner.invoke(app, ["validate", str(missing)])
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit code for missing file, got {result.exit_code}. "
+        f"Output:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TEST 4 — validate command rejects path with shell metacharacters
+# ---------------------------------------------------------------------------
+
+
+def test_validate_shell_metacharacter_path() -> None:
+    """validate command should reject paths containing shell metacharacters."""
+    malicious_path = "/tmp/workflow.yaml;rm -rf /"
+    result = runner.invoke(app, ["validate", malicious_path])
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit code for path with metacharacters, "
+        f"got {result.exit_code}. Output:\n{result.output}"
+    )
+
+
+def test_validate_pipe_metacharacter_path() -> None:
+    """validate command should reject paths containing a pipe character."""
+    malicious_path = "/tmp/workflow.yaml|cat /etc/passwd"
+    result = runner.invoke(app, ["validate", malicious_path])
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit code for path with '|', "
+        f"got {result.exit_code}. Output:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TEST 5 — plan command with valid workflow
+# ---------------------------------------------------------------------------
+
+
+def test_plan_valid_workflow(valid_workflow_file: Path) -> None:
+    """plan command exits 0 and outputs agent and team names."""
+    result = runner.invoke(app, ["plan", str(valid_workflow_file)])
+    assert result.exit_code == 0, f"Unexpected exit code. Output:\n{result.output}"
+    # Agent name and team name from the fixture YAML should appear
+    assert "worker" in result.output, (
+        f"Expected agent name 'worker' in plan output:\n{result.output}"
+    )
+    assert "team-a" in result.output, (
+        f"Expected team name 'team-a' in plan output:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TEST 6 — run command dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_run(valid_workflow_file: Path) -> None:
+    """run --dry-run exits 0 without connecting to Agamemnon."""
+    mock_state = MagicMock()
+    mock_state.workflow_id = "dry-run-id-123"
+    mock_state.status = "completed"
+
+    with patch("telemachy.cli.run_workflow", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = mock_state
+        result = runner.invoke(
+            app, ["run", str(valid_workflow_file), "--dry-run"]
+        )
+
+    assert result.exit_code == 0, (
+        f"Expected exit code 0 for --dry-run, got {result.exit_code}. "
+        f"Output:\n{result.output}"
+    )
+    # run_workflow should have been called once with dry_run=True
+    mock_run.assert_called_once()
+    _args, kwargs = mock_run.call_args
+    assert kwargs.get("dry_run") is True or (len(_args) > 1 and _args[1] is True), (
+        f"Expected run_workflow to be called with dry_run=True, "
+        f"call_args={mock_run.call_args}"
+    )


### PR DESCRIPTION
Add `tests/test_agamemnon_client.py` with HTTP interaction tests for `AgamemnonClient`:
- Happy-path agent creation, start, delete
- Error handling: 4xx raises `AgamemnonError`, malformed response raises `AgamemnonError`
- Retry behaviour: 503 × 2 then success
- TLS enforcement: `REQUIRE_TLS=true` with http:// URL raises at construction

Closes #9
