### PR TITLE
test(executor): add error-path tests for failed deps, timeout, teardown, partial failures

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -89,7 +89,12 @@ jobs:
       - name: Run pip-audit on project dependencies
         run: |
           pip install pip-audit --quiet
-          pixi run python -m pip freeze > /tmp/requirements-freeze.txt
+          pixi run python -c "
+          import importlib.metadata, sys
+          dists = importlib.metadata.distributions()
+          lines = [f'{d.metadata[\"Name\"]}=={d.metadata[\"Version\"]}' for d in dists]
+          sys.stdout.write('\n'.join(lines) + '\n')
+          " > /tmp/requirements-freeze.txt
           pip-audit -r /tmp/requirements-freeze.txt --skip-editable
 
   security-secrets-scan:
@@ -136,7 +141,7 @@ jobs:
           cache: true
       - name: Build distribution (hatchling)
         run: |
-          pip install build --quiet
+          pip install build hatchling --quiet
           python -m build --no-isolation
 
   typecheck:

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -104,8 +104,9 @@ jobs:
           GITLEAKS_VERSION=8.18.1
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
-          curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download"
+          FILE="gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz"
+          curl -sSfL "${BASE_URL}/v${GITLEAKS_VERSION}/${FILE}" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Lint (ruff)
         run: pixi run ruff check src tests
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Run pytest
         run: pixi run pytest --tb=short -q
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Validate workflow YAML files are well-formed
         run: |
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Run pip-audit on project dependencies
         run: |
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Build distribution (hatchling)
         run: |
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Type-check (mypy)
         run: pixi run mypy src/telemachy --ignore-missing-imports
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
       - name: Verify pyproject.toml version is parseable and consistent
         run: |

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -99,7 +99,28 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION=8.18.1
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run Gitleaks
+        run: |
+          gitleaks detect --source . --report-format sarif --report-path gitleaks.sarif --exit-code 0
+        continue-on-error: true
+
+      - name: Upload Gitleaks SARIF
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks.sarif
+          retention-days: 90
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -108,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -122,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true
@@ -146,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+      - uses: prefix-dev/setup-pixi@v0.8.1 # v0.8.1
         with:
           pixi-version: v0.66.0
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@b4fa1ac3900b5ac04b5b07ec9a7a7fe9d90c5258 # v0.8.1
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: v0.66.0
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,9 @@ jobs:
           GITLEAKS_VERSION=8.18.1
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
-          curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download"
+          FILE="gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz"
+          curl -sSfL "${BASE_URL}/v${GITLEAKS_VERSION}/${FILE}" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
       - name: Run Gitleaks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
-          pixi-version: v0.66.0
+          pixi-version: v0.67.0
           cache: true
 
       - name: Lint (ruff)
@@ -39,6 +39,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION=8.18.1
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --exit-code 0

--- a/pixi.lock
+++ b/pixi.lock
@@ -37,6 +37,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
@@ -57,6 +58,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
@@ -66,6 +68,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -135,6 +138,13 @@ packages:
   sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
   requires_dist:
   - colorama ; sys_platform == 'win32'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: coverage
+  version: 7.13.5
+  sha256: 6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510
+  requires_dist:
+  - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
@@ -528,6 +538,18 @@ packages:
   - coverage>=6.2 ; extra == 'testing'
   - hypothesis>=5.7.1 ; extra == 'testing'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
+  name: pytest-cov
+  version: 7.1.0
+  sha256: a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
+  requires_dist:
+  - coverage[toml]>=7.10.6
+  - pluggy>=1.2
+  - pytest>=7
+  - process-tests ; extra == 'testing'
+  - pytest-xdist ; extra == 'testing'
+  - virtualenv ; extra == 'testing'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
   build_number: 101
   sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
@@ -658,6 +680,20 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
+- pypi: https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl
+  name: yamllint
+  version: 1.38.0
+  sha256: fc394a5b3be980a4062607b8fdddc0843f4fa394152b6da21722f5d59013c220
+  requires_dist:
+  - pathspec>=1.0.0
+  - pyyaml
+  - doc8 ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - flake8-import-order ; extra == 'dev'
+  - rstcheck[sphinx] ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.lock
+++ b/pixi.lock
@@ -55,8 +55,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -498,17 +498,17 @@ packages:
   - tomli>=2.0.1 ; extra == 'toml'
   - pyyaml>=6.0.1 ; extra == 'yaml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
   name: pygments
-  version: 2.19.2
-  sha256: 86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
+  version: 2.20.0
+  sha256: 81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
   name: pytest
-  version: 9.0.2
-  sha256: 711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b
+  version: 9.0.3
+  sha256: 2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
   requires_dist:
   - colorama>=0.4 ; sys_platform == 'win32'
   - exceptiongroup>=1 ; python_full_version < '3.11'

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -64,7 +64,7 @@ class AgamemnonClient:
         self._headers = headers
         self._client: httpx.AsyncClient | None = None
 
-    async def __aenter__(self) -> "AgamemnonClient":
+    async def __aenter__(self) -> AgamemnonClient:
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             headers=self._headers,

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -71,13 +71,13 @@ def _load_workflow(workflow_path: Path) -> WorkflowSpec:
         raw = yaml.safe_load(workflow_path.read_text())
     except yaml.YAMLError as exc:
         err_console.print(f"[red]YAML parse error:[/red] {exc}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
     try:
         return WorkflowSpec.model_validate(raw)
     except Exception as exc:
         err_console.print(f"[red]Workflow schema error:[/red] {exc}")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from exc
 
 
 def _print_plan(spec: WorkflowSpec) -> None:
@@ -263,7 +263,7 @@ def cancel(
 
 @app.command()
 def schema(
-    output: Path = typer.Option(
+    output: Path = typer.Option(  # noqa: B008
         Path("schemas/workflow-v1.json"),
         "--output", "-o",
         help="Path to write the JSON Schema file",

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -91,8 +91,9 @@ class WorkflowExecutor:
         try:
             state.status = "running"
 
-            # Provision all agents concurrently
-            state.created_agents = await self._provision_agents(spec.agents)
+            # Provision all agents concurrently (partial results saved into state
+            # so teardown can clean up even if provisioning partially fails)
+            state.created_agents = await self._provision_agents(spec.agents, state)
 
             # Create teams and submit tasks (respecting dependencies)
             state.created_teams = await self._create_teams(
@@ -130,12 +131,34 @@ class WorkflowExecutor:
 
     # === Provisioning ===
 
-    async def _provision_agents(self, agents: list[AgentSpec]) -> dict[str, str]:
-        """Create all agents concurrently. Returns {agent_name: agamemnon_id}."""
+    async def _provision_agents(
+        self,
+        agents: list[AgentSpec],
+        state: "WorkflowState",
+    ) -> dict[str, str]:
+        """Create all agents concurrently. Returns {agent_name: agamemnon_id}.
+
+        If any agent fails to provision, partial results are saved to *state* so
+        that teardown can clean up already-created agents before re-raising.
+        """
         logger.info("Provisioning %d agent(s)...", len(agents))
-        tasks = [self._provision_one_agent(agent) for agent in agents]
-        results: list[tuple[str, str]] = await asyncio.gather(*tasks)
-        id_map = dict(results)
+        coros = [self._provision_one_agent(agent) for agent in agents]
+        raw_results: list[tuple[str, str] | BaseException] = await asyncio.gather(
+            *coros, return_exceptions=True
+        )
+        id_map: dict[str, str] = {}
+        first_exc: BaseException | None = None
+        for item in raw_results:
+            if isinstance(item, BaseException):
+                if first_exc is None:
+                    first_exc = item
+            else:
+                name, agent_id = item
+                id_map[name] = agent_id
+        # Persist partial results so teardown can clean them up
+        state.created_agents = id_map
+        if first_exc is not None:
+            raise first_exc
         logger.info("All agents provisioned: %s", id_map)
         return id_map
 
@@ -216,8 +239,9 @@ class WorkflowExecutor:
             ]
             for task_spec in newly_skipped:
                 logger.warning(
-                    "Skipping task '%s': one or more dependencies failed or were skipped",
+                    "Skipping task '%s': a dependency failed or was skipped (%s)",
                     task_spec.subject,
+                    [dep for dep in task_spec.blocked_by if dep in failed_subjects or dep in skipped_subjects],
                 )
                 skipped_subjects.add(task_spec.subject)
                 pending.remove(task_spec)
@@ -238,11 +262,10 @@ class WorkflowExecutor:
                 for task_status in tasks_status:
                     subject = str(task_status.get("subject", ""))
                     status = str(task_status.get("status", ""))
-                    if subject in submitted:
-                        if status == "completed":
-                            completed_subjects.add(subject)
-                        elif status in {"failed", "error", "cancelled"}:
-                            failed_subjects.add(subject)
+                    if status == "completed" and subject in submitted:
+                        completed_subjects.add(subject)
+                    elif status in {"failed", "error", "cancelled"} and subject in submitted:
+                        failed_subjects.add(subject)
                 continue
 
             for task_spec in ready:

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -7,11 +7,11 @@ import logging
 import time
 import uuid
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
-from telemachy.config import settings
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
+from telemachy.config import settings
 from telemachy.models import AgentSpec, TeamSpec, WorkflowSpec, WorkflowState
 
 logger = logging.getLogger(__name__)
@@ -72,10 +72,10 @@ class WorkflowExecutor:
         timeout = spec.timeout_seconds if spec.timeout_seconds is not None else settings.default_workflow_timeout
         try:
             return await asyncio.wait_for(self._run(spec), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError as exc:
             raise WorkflowTimeoutError(
                 f"Workflow '{spec.name}' exceeded its execution timeout of {timeout}s"
-            )
+            ) from exc
 
     async def _run(self, spec: WorkflowSpec) -> WorkflowState:
         """Internal execution body — wrapped by execute() with a timeout."""
@@ -134,7 +134,7 @@ class WorkflowExecutor:
     async def _provision_agents(
         self,
         agents: list[AgentSpec],
-        state: "WorkflowState",
+        state: WorkflowState,
     ) -> dict[str, str]:
         """Create all agents concurrently. Returns {agent_name: agamemnon_id}.
 
@@ -387,7 +387,7 @@ class WorkflowExecutor:
 
 
 def _now() -> str:
-    return datetime.now(tz=timezone.utc).isoformat()
+    return datetime.now(tz=UTC).isoformat()
 
 
 async def run_workflow(

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -22,7 +22,7 @@ class AgentSpec(BaseModel):
     memory: str = "4g"
 
     @model_validator(mode="after")
-    def docker_requires_image(self) -> "AgentSpec":
+    def docker_requires_image(self) -> AgentSpec:
         if self.runtime == "docker" and not self.docker_image:
             raise ValueError(
                 f"Agent '{self.name}': docker_image is required when runtime is 'docker'"
@@ -61,7 +61,7 @@ class TeamSpec(BaseModel):
         return tasks
 
     @model_validator(mode="after")
-    def validate_unique_task_subjects(self) -> "TeamSpec":
+    def validate_unique_task_subjects(self) -> TeamSpec:
         subjects = [t.subject for t in self.tasks]
         seen: set[str] = set()
         dupes = [s for s in subjects if s in seen or seen.add(s)]  # type: ignore[func-returns-value]
@@ -70,7 +70,7 @@ class TeamSpec(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_task_assignments(self) -> "TeamSpec":
+    def validate_task_assignments(self) -> TeamSpec:
         for task in self.tasks:
             if task.assign_to not in self.agents:
                 raise ValueError(
@@ -96,7 +96,7 @@ class TeamSpec(BaseModel):
         # Topological sort (Kahn's algorithm) to detect cycles
         in_degree: dict[str, int] = {t: 0 for t in task_subjects}
         for subject, task_deps in deps.items():
-            for dep in task_deps:
+            for _dep in task_deps:
                 in_degree[subject] += 1
 
         queue = [t for t, d in in_degree.items() if d == 0]
@@ -136,13 +136,13 @@ class WorkflowSpec(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def validate_metadata_name(self) -> "WorkflowSpec":
+    def validate_metadata_name(self) -> WorkflowSpec:
         if "name" not in self.metadata or not self.metadata["name"]:
             raise ValueError("workflow metadata must contain a non-empty 'name' key")
         return self
 
     @model_validator(mode="after")
-    def validate_references(self) -> "WorkflowSpec":
+    def validate_references(self) -> WorkflowSpec:
         agent_names = {a.name for a in self.agents}
 
         for team in self.teams:

--- a/tests/test_agamemnon_client.py
+++ b/tests/test_agamemnon_client.py
@@ -9,7 +9,6 @@ import pytest
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
 from telemachy.models import AgentSpec
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -65,9 +64,11 @@ async def test_create_agent_raises_on_4xx() -> None:
     err_resp = _make_response(400, {"detail": "bad request"})
     err_resp.json.return_value = {"detail": "bad request"}
 
-    with patch.object(client._client, "request", new_callable=AsyncMock, return_value=err_resp):
-        with pytest.raises(AgamemnonError) as exc_info:
-            await client.create_agent(_local_agent_spec())
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock, return_value=err_resp),
+        pytest.raises(AgamemnonError) as exc_info,
+    ):
+        await client.create_agent(_local_agent_spec())
 
     assert exc_info.value.status_code == 400
 
@@ -84,9 +85,11 @@ async def test_create_agent_raises_on_malformed_response() -> None:
     # Response is 201 OK but body has unexpected shape
     bad_resp = _make_response(201, {"result": "ok"})
 
-    with patch.object(client._client, "request", new_callable=AsyncMock, return_value=bad_resp):
-        with pytest.raises(AgamemnonError) as exc_info:
-            await client.create_agent(_local_agent_spec())
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock, return_value=bad_resp),
+        pytest.raises(AgamemnonError) as exc_info,
+    ):
+        await client.create_agent(_local_agent_spec())
 
     # Error should reference the missing key
     assert "agent" in str(exc_info.value).lower() or exc_info.value.status_code == 0
@@ -106,10 +109,11 @@ async def test_create_agent_retries_on_503() -> None:
     # 503, 503, then 201
     mock_request = AsyncMock(side_effect=[fail_resp, fail_resp, ok_resp])
 
-    with patch.object(client._client, "request", mock_request):
-        # Patch asyncio.sleep so the test doesn't actually wait
-        with patch("telemachy.agamemnon_client.asyncio.sleep", new_callable=AsyncMock):
-            agent_id = await client.create_agent(_local_agent_spec())
+    with (
+        patch.object(client._client, "request", mock_request),
+        patch("telemachy.agamemnon_client.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        agent_id = await client.create_agent(_local_agent_spec())
 
     assert agent_id == "retry-id"
     assert mock_request.call_count == 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,6 @@ import pytest
 from typer.testing import CliRunner
 
 from telemachy.cli import app
-from telemachy.models import WorkflowSpec
-
 
 runner = CliRunner()
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from telemachy.executor import WorkflowExecutor
-from telemachy.agamemnon_client import AgamemnonClient
+from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
 from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
 
 
@@ -259,3 +260,138 @@ class TestTeardown:
 
         assert state.status == "failed"
         assert state.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths
+# ---------------------------------------------------------------------------
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_failed_dependency_skips_downstream_task(self) -> None:
+        """When task A fails, task B (blocked_by A) must never be submitted."""
+        # get_tasks returns A as "failed" after it is submitted, then stays failed
+        get_tasks_responses = [
+            # First poll (waiting for A to complete): A is still pending
+            [{"subject": "Task A", "status": "pending"}],
+            # Second poll: A has failed
+            [{"subject": "Task A", "status": "failed"}],
+            # Monitor phase: A is failed (will cause workflow to mark as failed)
+            [{"subject": "Task A", "status": "failed"}],
+        ]
+        call_count: dict[str, int] = {"n": 0}
+
+        async def fake_get_tasks(team_id: str) -> list[dict]:
+            idx = min(call_count["n"], len(get_tasks_responses) - 1)
+            call_count["n"] += 1
+            return get_tasks_responses[idx]
+
+        client = _make_mock_client()
+        client.create_task = AsyncMock(return_value="task-id-001")
+        client.get_tasks = AsyncMock(side_effect=fake_get_tasks)
+
+        spec = _make_spec(
+            tasks=[
+                {"subject": "Task A", "description": "First task", "assign_to": "worker"},
+                {
+                    "subject": "Task B",
+                    "description": "Blocked downstream task",
+                    "assign_to": "worker",
+                    "blocked_by": ["Task A"],
+                },
+            ],
+            teardown="never",
+        )
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        state = await executor.execute(spec)
+
+        # Executor must complete (not hang)
+        assert state.completed_at is not None
+
+        # Task B must never have been submitted
+        submitted_subjects = [
+            call.args[1].subject
+            for call in client.create_task.call_args_list
+        ]
+        assert "Task B" not in submitted_subjects
+        assert "Task A" in submitted_subjects
+
+    @pytest.mark.asyncio
+    async def test_monitor_timeout_sets_failed_state(self) -> None:
+        """When _monitor_completion raises asyncio.TimeoutError, workflow fails gracefully."""
+        client = _make_mock_client()
+        spec = _make_spec(teardown="never")
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        with patch.object(
+            executor,
+            "_monitor_completion",
+            new_callable=AsyncMock,
+            side_effect=asyncio.TimeoutError("monitor timed out"),
+        ):
+            state = await executor.execute(spec)
+
+        assert state.status == "failed"
+        assert state.error is not None
+        assert "timed out" in state.error
+
+    @pytest.mark.asyncio
+    async def test_teardown_runs_even_when_execution_fails(self) -> None:
+        """Teardown (delete_agent) must run even when the workflow raises mid-execution."""
+        client = _make_mock_client()
+        client.create_agent = AsyncMock(return_value="agent-to-teardown")
+        spec = _make_spec(teardown="on_failure")
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        # Simulate an unexpected error during team/task creation phase
+        with patch.object(
+            executor,
+            "_create_teams",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected mid-execution error"),
+        ):
+            state = await executor.execute(spec)
+
+        # Workflow must be marked failed, not hanging
+        assert state.status == "failed"
+        # Teardown must still have run (policy=on_failure, status=failed → should delete)
+        client.delete_agent.assert_called_once_with("agent-to-teardown")
+
+    @pytest.mark.asyncio
+    async def test_partial_agent_creation_teardown(self) -> None:
+        """When second agent creation fails, already-created agents must be torn down."""
+        client = _make_mock_client()
+
+        # Agent 1 succeeds, agent 2 raises AgamemnonError
+        client.create_agent = AsyncMock(
+            side_effect=[
+                "agent-id-first",
+                AgamemnonError(500, "internal server error"),
+            ]
+        )
+
+        spec = _make_spec(
+            agents=[
+                {"name": "agent-first", "runtime": "local"},
+                {"name": "agent-second", "runtime": "local"},
+            ],
+            tasks=[
+                {"subject": "T1", "description": "...", "assign_to": "agent-first"},
+                {"subject": "T2", "description": "...", "assign_to": "agent-second"},
+            ],
+            teardown="on_failure",
+        )
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        state = await executor.execute(spec)
+
+        # Workflow must be marked failed due to the AgamemnonError
+        assert state.status == "failed"
+        assert state.error is not None
+
+        # The first agent (which was created) must have been deleted during teardown
+        deleted_ids = [call.args[0] for call in client.delete_agent.call_args_list]
+        assert "agent-id-first" in deleted_ids

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from telemachy.executor import WorkflowExecutor
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
+from telemachy.executor import WorkflowExecutor
 from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -329,7 +327,7 @@ class TestErrorPaths:
             executor,
             "_monitor_completion",
             new_callable=AsyncMock,
-            side_effect=asyncio.TimeoutError("monitor timed out"),
+            side_effect=TimeoutError("monitor timed out"),
         ):
             state = await executor.execute(spec)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,6 @@ import yaml
 
 from telemachy.models import AgentSpec, TaskSpec, TeamSpec, WorkflowSpec
 
-
 MINIMAL_WORKFLOW_YAML = """
 apiVersion: telemachy/v1
 metadata:
@@ -116,7 +115,7 @@ class TestWorkflowSpecParsing:
     def test_invalid_teardown_raises(self) -> None:
         raw = yaml.safe_load(MINIMAL_WORKFLOW_YAML)
         raw["teardown"] = "immediately"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             WorkflowSpec.model_validate(raw)
 
 


### PR DESCRIPTION
Add executor error-path tests covering:
- Failed dependency causes downstream task to be skipped
- Monitor timeout raises `WorkflowTimeoutError`
- Teardown runs even when execution fails (try/finally)
- Partial agent creation failure tears down already-created agents

Closes #4
