### PR TITLE
feat: add JSON Schema export for workflow YAML validation

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,10 @@ cancel WORKFLOW_ID:
 validate WORKFLOW:
     pixi run python -m telemachy.cli validate {{WORKFLOW}}
 
+# Export workflow JSON Schema for editor validation
+schema:
+    pixi run python -m telemachy.cli schema
+
 # === Development ===
 
 # Run the test suite

--- a/schemas/workflow-v1.json
+++ b/schemas/workflow-v1.json
@@ -1,0 +1,195 @@
+{
+  "$defs": {
+    "AgentSpec": {
+      "additionalProperties": false,
+      "description": "Specification for a single Agamemnon agent to provision.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "program": {
+          "default": "claude-code",
+          "title": "Program",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "working_dir": {
+          "default": "/tmp",
+          "title": "Working Dir",
+          "type": "string"
+        },
+        "runtime": {
+          "default": "local",
+          "enum": [
+            "local",
+            "docker"
+          ],
+          "title": "Runtime",
+          "type": "string"
+        },
+        "docker_image": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Docker Image"
+        },
+        "cpus": {
+          "default": 2,
+          "title": "Cpus",
+          "type": "integer"
+        },
+        "memory": {
+          "default": "4g",
+          "title": "Memory",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "AgentSpec",
+      "type": "object"
+    },
+    "TaskSpec": {
+      "additionalProperties": false,
+      "description": "Specification for a single task within a team.",
+      "properties": {
+        "subject": {
+          "title": "Subject",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "assign_to": {
+          "title": "Assign To",
+          "type": "string"
+        },
+        "blocked_by": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Blocked By",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subject",
+        "description",
+        "assign_to"
+      ],
+      "title": "TaskSpec",
+      "type": "object"
+    },
+    "TeamSpec": {
+      "additionalProperties": false,
+      "description": "Specification for a team of agents and their tasks.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "agents": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Agents",
+          "type": "array"
+        },
+        "tasks": {
+          "items": {
+            "$ref": "#/$defs/TaskSpec"
+          },
+          "title": "Tasks",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "agents",
+        "tasks"
+      ],
+      "title": "TeamSpec",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Top-level workflow specification parsed from a workflow YAML file.",
+  "properties": {
+    "apiVersion": {
+      "default": "telemachy/v1",
+      "title": "Apiversion",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Metadata",
+      "type": "object"
+    },
+    "agents": {
+      "items": {
+        "$ref": "#/$defs/AgentSpec"
+      },
+      "title": "Agents",
+      "type": "array"
+    },
+    "teams": {
+      "items": {
+        "$ref": "#/$defs/TeamSpec"
+      },
+      "title": "Teams",
+      "type": "array"
+    },
+    "teardown": {
+      "default": "on_completion",
+      "enum": [
+        "on_completion",
+        "on_failure",
+        "never"
+      ],
+      "title": "Teardown",
+      "type": "string"
+    },
+    "timeout_seconds": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timeout Seconds"
+    }
+  },
+  "required": [
+    "metadata",
+    "agents",
+    "teams"
+  ],
+  "title": "WorkflowSpec",
+  "type": "object"
+}

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -261,6 +261,21 @@ def cancel(
     )
 
 
+@app.command()
+def schema(
+    output: Path = typer.Option(
+        Path("schemas/workflow-v1.json"),
+        "--output", "-o",
+        help="Path to write the JSON Schema file",
+    ),
+) -> None:
+    """Export the workflow YAML JSON Schema for editor validation."""
+    from telemachy.schema import write_workflow_schema
+    output.parent.mkdir(parents=True, exist_ok=True)
+    write_workflow_schema(output)
+    typer.echo(f"Schema written to {output}")
+
+
 def main() -> None:
     _setup_logging()
     app()

--- a/src/telemachy/schema.py
+++ b/src/telemachy/schema.py
@@ -1,0 +1,19 @@
+"""JSON Schema export for workflow YAML validation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from telemachy.models import WorkflowSpec
+
+
+def get_workflow_schema() -> dict[str, Any]:
+    """Return the JSON Schema for WorkflowSpec."""
+    return WorkflowSpec.model_json_schema()
+
+
+def write_workflow_schema(path: Path) -> None:
+    """Write the workflow JSON Schema to a file."""
+    schema = get_workflow_schema()
+    path.write_text(json.dumps(schema, indent=2) + "\n")


### PR DESCRIPTION
Add JSON Schema export for workflow YAML validation:
- `src/telemachy/schema.py` — `get_workflow_schema()` and `write_workflow_schema()` using `WorkflowSpec.model_json_schema()`
- `just schema` / `telemachy schema` CLI command to (re-)generate the schema file
- `schemas/workflow-v1.json` — committed generated schema for editor integration

Closes #52
