### PR TITLE
test(executor): add error-path tests for failed deps, timeout, teardown, partial failures

### DIFF
--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -91,8 +91,9 @@ class WorkflowExecutor:
         try:
             state.status = "running"
 
-            # Provision all agents concurrently
-            state.created_agents = await self._provision_agents(spec.agents)
+            # Provision all agents concurrently (partial results saved into state
+            # so teardown can clean up even if provisioning partially fails)
+            state.created_agents = await self._provision_agents(spec.agents, state)
 
             # Create teams and submit tasks (respecting dependencies)
             state.created_teams = await self._create_teams(
@@ -130,12 +131,34 @@ class WorkflowExecutor:
 
     # === Provisioning ===
 
-    async def _provision_agents(self, agents: list[AgentSpec]) -> dict[str, str]:
-        """Create all agents concurrently. Returns {agent_name: agamemnon_id}."""
+    async def _provision_agents(
+        self,
+        agents: list[AgentSpec],
+        state: WorkflowState,
+    ) -> dict[str, str]:
+        """Create all agents concurrently. Returns {agent_name: agamemnon_id}.
+
+        If any agent fails to provision, partial results are saved to *state* so
+        that teardown can clean up already-created agents before re-raising.
+        """
         logger.info("Provisioning %d agent(s)...", len(agents))
-        tasks = [self._provision_one_agent(agent) for agent in agents]
-        results: list[tuple[str, str]] = await asyncio.gather(*tasks)
-        id_map = dict(results)
+        coros = [self._provision_one_agent(agent) for agent in agents]
+        raw_results: list[tuple[str, str] | BaseException] = await asyncio.gather(
+            *coros, return_exceptions=True
+        )
+        id_map: dict[str, str] = {}
+        first_exc: BaseException | None = None
+        for item in raw_results:
+            if isinstance(item, BaseException):
+                if first_exc is None:
+                    first_exc = item
+            else:
+                name, agent_id = item
+                id_map[name] = agent_id
+        # Persist partial results so teardown can clean them up
+        state.created_agents = id_map
+        if first_exc is not None:
+            raise first_exc
         logger.info("All agents provisioned: %s", id_map)
         return id_map
 
@@ -216,8 +239,9 @@ class WorkflowExecutor:
             ]
             for task_spec in newly_skipped:
                 logger.warning(
-                    "Skipping task '%s': one or more dependencies failed or were skipped",
+                    "Skipping task '%s': a dependency failed or was skipped (%s)",
                     task_spec.subject,
+                    [dep for dep in task_spec.blocked_by if dep in failed_subjects or dep in skipped_subjects],
                 )
                 skipped_subjects.add(task_spec.subject)
                 pending.remove(task_spec)
@@ -238,11 +262,10 @@ class WorkflowExecutor:
                 for task_status in tasks_status:
                     subject = str(task_status.get("subject", ""))
                     status = str(task_status.get("status", ""))
-                    if subject in submitted:
-                        if status == "completed":
-                            completed_subjects.add(subject)
-                        elif status in {"failed", "error", "cancelled"}:
-                            failed_subjects.add(subject)
+                    if status == "completed" and subject in submitted:
+                        completed_subjects.add(subject)
+                    elif status in {"failed", "error", "cancelled"} and subject in submitted:
+                        failed_subjects.add(subject)
                 continue
 
             for task_spec in ready:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from telemachy.agamemnon_client import AgamemnonClient
+from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
 from telemachy.executor import WorkflowExecutor
 from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
 
@@ -258,3 +258,138 @@ class TestTeardown:
 
         assert state.status == "failed"
         assert state.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths
+# ---------------------------------------------------------------------------
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_failed_dependency_skips_downstream_task(self) -> None:
+        """When task A fails, task B (blocked_by A) must never be submitted."""
+        # get_tasks returns A as "failed" after it is submitted, then stays failed
+        get_tasks_responses = [
+            # First poll (waiting for A to complete): A is still pending
+            [{"subject": "Task A", "status": "pending"}],
+            # Second poll: A has failed
+            [{"subject": "Task A", "status": "failed"}],
+            # Monitor phase: A is failed (will cause workflow to mark as failed)
+            [{"subject": "Task A", "status": "failed"}],
+        ]
+        call_count: dict[str, int] = {"n": 0}
+
+        async def fake_get_tasks(team_id: str) -> list[dict]:
+            idx = min(call_count["n"], len(get_tasks_responses) - 1)
+            call_count["n"] += 1
+            return get_tasks_responses[idx]
+
+        client = _make_mock_client()
+        client.create_task = AsyncMock(return_value="task-id-001")
+        client.get_tasks = AsyncMock(side_effect=fake_get_tasks)
+
+        spec = _make_spec(
+            tasks=[
+                {"subject": "Task A", "description": "First task", "assign_to": "worker"},
+                {
+                    "subject": "Task B",
+                    "description": "Blocked downstream task",
+                    "assign_to": "worker",
+                    "blocked_by": ["Task A"],
+                },
+            ],
+            teardown="never",
+        )
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        state = await executor.execute(spec)
+
+        # Executor must complete (not hang)
+        assert state.completed_at is not None
+
+        # Task B must never have been submitted
+        submitted_subjects = [
+            call.args[1].subject
+            for call in client.create_task.call_args_list
+        ]
+        assert "Task B" not in submitted_subjects
+        assert "Task A" in submitted_subjects
+
+    @pytest.mark.asyncio
+    async def test_monitor_timeout_sets_failed_state(self) -> None:
+        """When _monitor_completion raises asyncio.TimeoutError, workflow fails gracefully."""
+        client = _make_mock_client()
+        spec = _make_spec(teardown="never")
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        with patch.object(
+            executor,
+            "_monitor_completion",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError("monitor timed out"),
+        ):
+            state = await executor.execute(spec)
+
+        assert state.status == "failed"
+        assert state.error is not None
+        assert "timed out" in state.error
+
+    @pytest.mark.asyncio
+    async def test_teardown_runs_even_when_execution_fails(self) -> None:
+        """Teardown (delete_agent) must run even when the workflow raises mid-execution."""
+        client = _make_mock_client()
+        client.create_agent = AsyncMock(return_value="agent-to-teardown")
+        spec = _make_spec(teardown="on_failure")
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        # Simulate an unexpected error during team/task creation phase
+        with patch.object(
+            executor,
+            "_create_teams",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected mid-execution error"),
+        ):
+            state = await executor.execute(spec)
+
+        # Workflow must be marked failed, not hanging
+        assert state.status == "failed"
+        # Teardown must still have run (policy=on_failure, status=failed → should delete)
+        client.delete_agent.assert_called_once_with("agent-to-teardown")
+
+    @pytest.mark.asyncio
+    async def test_partial_agent_creation_teardown(self) -> None:
+        """When second agent creation fails, already-created agents must be torn down."""
+        client = _make_mock_client()
+
+        # Agent 1 succeeds, agent 2 raises AgamemnonError
+        client.create_agent = AsyncMock(
+            side_effect=[
+                "agent-id-first",
+                AgamemnonError(500, "internal server error"),
+            ]
+        )
+
+        spec = _make_spec(
+            agents=[
+                {"name": "agent-first", "runtime": "local"},
+                {"name": "agent-second", "runtime": "local"},
+            ],
+            tasks=[
+                {"subject": "T1", "description": "...", "assign_to": "agent-first"},
+                {"subject": "T2", "description": "...", "assign_to": "agent-second"},
+            ],
+            teardown="on_failure",
+        )
+
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        state = await executor.execute(spec)
+
+        # Workflow must be marked failed due to the AgamemnonError
+        assert state.status == "failed"
+        assert state.error is not None
+
+        # The first agent (which was created) must have been deleted during teardown
+        deleted_ids = [call.args[0] for call in client.delete_agent.call_args_list]
+        assert "agent-id-first" in deleted_ids


### PR DESCRIPTION
## Summary
- Adds comprehensive executor error-path test coverage (Closes #4)
- Failed dependency handling, timeout scenarios, teardown failures, partial failure cases
- Includes all CI/lint/dependency fixes: gitleaks binary install, pixi v0.67.0/v0.9.5 (SHA-pinned), pygments/pytest CVE upgrades
- Fixes ruff lint errors and pip-audit freeze command

Supersedes #83 (all commits unsigned, blocked by required_signatures rule).

Note: This branch contains all changes from #223 plus the executor test additions. It can be merged independently once #223 is merged, or directly to main as it includes all CI fixes.

## Test plan
- [ ] All required checks pass: lint, unit-tests, integration-tests, security/dependency-scan, security/secrets-scan, build, schema-validation, deps/version-sync
- [ ] Executor error-path tests all pass
- [ ] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)