### PR TITLE
docs(templates): fix markdownlint MD022/MD032/MD009/MD013 violations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,20 +5,25 @@ labels: bug
 ---
 
 ## Description
+
 <!-- A clear description of the bug -->
 
 ## Steps to reproduce
-1. 
-2. 
-3. 
+
+1. Step one
+2. Step two
+3. Step three
 
 ## Expected behavior
+
 <!-- What you expected to happen -->
 
 ## Actual behavior
+
 <!-- What actually happened -->
 
 ## Environment
-- OS: 
-- Python version: 
-- Telemachy version: 
+
+- OS:
+- Python version:
+- Telemachy version:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,13 @@
 ## Summary
+
 <!-- What does this PR do? -->
 
 ## Related issues
+
 <!-- Closes #N -->
 
 ## Test plan
+
 - [ ] Tests pass (`just test`)
 - [ ] Linting passes (`just lint`)
 - [ ] Tested locally with `just validate workflows/example.yaml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,13 @@
 
 ## Project Overview
 
-ProjectTelemachy is a declarative workflow engine that automates multi-agent workflows by calling the ProjectAgamemnon REST API. Users define workflows in YAML; Telemachy parses them, provisions agents and teams via Agamemnon, assigns tasks with dependency ordering, monitors execution via NATS events, and tears down resources according to the workflow's teardown policy.
+ProjectTelemachy is a declarative workflow engine that automates multi-agent workflows by calling the
+ProjectAgamemnon REST API. Users define workflows in YAML; Telemachy parses them, provisions agents and
+teams via Agamemnon, assigns tasks with dependency ordering, monitors execution via NATS events, and
+tears down resources according to the workflow's teardown policy.
 
-**This project uses ProjectAgamemnon exclusively as its execution backend.** There is no parallel agent system — all agent lifecycle management flows through Agamemnon's REST API.
+**This project uses ProjectAgamemnon exclusively as its execution backend.**
+There is no parallel agent system — all agent lifecycle management flows through Agamemnon's REST API.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # ProjectTelemachy
 
-A declarative workflow engine for [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon). Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, event monitoring, and teardown via the Agamemnon REST API.
+A declarative workflow engine for [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon).
+Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, event monitoring,
+and teardown via the Agamemnon REST API.
 
 ## Overview
 
-Telemachy reads a workflow YAML file, creates agents and teams through ProjectAgamemnon, assigns tasks with dependency ordering, monitors task completion via NATS events, and tears down provisioned resources according to your policy.
+Telemachy reads a workflow YAML file, creates agents and teams through ProjectAgamemnon, assigns tasks
+with dependency ordering, monitors task completion via NATS events, and tears down provisioned resources
+according to your policy.
 
 No separate agent system is used. All execution is driven exclusively through ProjectAgamemnon.
 


### PR DESCRIPTION
Fixes the markdownlint violations on main that cause PR #90 to fail CI.

**Violations fixed:**
- `.github/ISSUE_TEMPLATE/bug_report.md`: MD022 (blanks-around-headings), MD032 (blanks-around-lists), MD009 (trailing-spaces)
- `.github/pull_request_template.md`: MD022, MD032
- `CLAUDE.md`: MD013 (line-length > 120 chars on lines 5, 7)
- `README.md`: MD013 (line-length > 120 chars on lines 3, 7)

Once merged, PR #90 can rebase onto main and the markdownlint check will pass.