### PR TITLE
fix(docs): replace noreply enforcement email in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
-responsible for enforcement at <4211002+mvillmow@users.noreply.github.com>. All complaints will be reviewed and investigated.
+responsible for enforcement at <conduct@homericintelligence.dev>. All complaints will be reviewed and investigated.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
Replace the GitHub noreply enforcement contact with a real email address so community members can report CoC violations.

Closes #188