### PR TITLE
chore: document removal timeline for maestro_client.py deprecation shim

### DIFF
--- a/src/telemachy/maestro_client.py
+++ b/src/telemachy/maestro_client.py
@@ -1,7 +1,11 @@
 """DEPRECATED: Use agamemnon_client instead.
 
 This module is kept for backward compatibility. All symbols are re-exported
-from agamemnon_client. Will be removed in a future release.
+from agamemnon_client.
+
+.. deprecated::
+    Scheduled for removal in v1.0.0. Update all imports to use
+    ``telemachy.agamemnon_client`` directly.
 """
 
 from telemachy.agamemnon_client import AgamemnonClient as AgamemnonClient


### PR DESCRIPTION
Add an explicit v1.0.0 removal target and migration instruction to the `maestro_client.py` docstring so contributors know when it will be removed and what to use instead.

Closes #189