### PR TITLE
docs: document all 10 settings in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,32 @@
+# ProjectTelemachy — environment variable reference
+# Copy this file to .env and fill in the values for your environment.
+
+# Agamemnon API base URL
 AGAMEMNON_URL=http://localhost:8080
+
+# Agamemnon API key (leave blank for unauthenticated local dev)
 AGAMEMNON_API_KEY=
+
+# NATS server URL used for event streaming
 NATS_URL=nats://localhost:4222
+
+# Directory to search for workflow YAML files (relative or absolute)
+WORKFLOWS_DIR=workflows
+
+# Identifier for this host, embedded in Agamemnon task assignments
+HOST_ID=hermes
+
+# Set to true to reject non-TLS Agamemnon connections
+REQUIRE_TLS=false
+
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL=INFO
+
+# Seconds to wait before timing out workflow monitor polling
+MONITOR_TIMEOUT_SECONDS=3600
+
+# Maximum number of polling attempts for workflow monitor
+MONITOR_MAX_POLLS=7200
+
+# Default per-workflow execution timeout in seconds
+DEFAULT_WORKFLOW_TIMEOUT=7200


### PR DESCRIPTION
Add the 7 missing environment variables to `.env.example` with inline comments, closing the discovery gap for new contributors who rely on this file to understand available configuration.

Closes #190