### PR TITLE
refactor(config): add Settings.client_kwargs() to deduplicate AgamemnonClient construction

### DIFF
--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -175,13 +175,7 @@ def run(
                     ),
                 )
 
-            async with AgamemnonClient(
-                url=settings.agamemnon_url,
-                api_key=settings.agamemnon_api_key,
-                host_id=settings.host_id,
-                require_tls=settings.require_tls,
-                nats_url=settings.nats_url,
-            ) as client:
+            async with AgamemnonClient(**settings.client_kwargs()) as client:
                 executor = WorkflowExecutor(client, stop_event=stop_event)
                 executor.add_hook("on_task_complete", _on_task_complete)
                 result = await executor.execute(spec)

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -27,5 +27,19 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     default_workflow_timeout: float = 7200.0
 
+    def client_kwargs(self) -> dict[str, object]:
+        """Return keyword arguments for constructing an AgamemnonClient.
+
+        Both ``cli.run`` and ``executor.run_workflow`` must use this so that
+        client construction stays DRY and all settings are applied uniformly.
+        """
+        return {
+            "url": self.agamemnon_url,
+            "api_key": self.agamemnon_api_key,
+            "host_id": self.host_id,
+            "require_tls": self.require_tls,
+            "nats_url": self.nats_url,
+        }
+
 
 settings = Settings()

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -396,12 +396,6 @@ async def run_workflow(
     stop_event: asyncio.Event | None = None,
 ) -> WorkflowState:
     """Convenience function: create a client from settings and execute a workflow."""
-    async with AgamemnonClient(
-        url=settings.agamemnon_url,
-        api_key=settings.agamemnon_api_key,
-        host_id=settings.host_id,
-        require_tls=settings.require_tls,
-        nats_url=settings.nats_url,
-    ) as client:
+    async with AgamemnonClient(**settings.client_kwargs()) as client:
         executor = WorkflowExecutor(client, dry_run=dry_run, stop_event=stop_event)
         return await executor.execute(spec)


### PR DESCRIPTION
`cli.run` and `executor.run_workflow` both spelled out all five `AgamemnonClient` constructor parameters independently. This PR introduces `Settings.client_kwargs()` as the single source of truth and updates both call sites to use it, eliminating the duplication.

Closes #204