### PR TITLE
fix(mypy): tighten kwargs typing for AgamemnonClient construction

### DIFF
--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -3,8 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypedDict
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AgamemnonClientKwargs(TypedDict):
+    """Typed kwargs matching AgamemnonClient.__init__ parameters."""
+
+    url: str
+    api_key: str
+    host_id: str
+    require_tls: bool
+    nats_url: str
 
 
 class Settings(BaseSettings):
@@ -27,7 +38,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     default_workflow_timeout: float = 7200.0
 
-    def client_kwargs(self) -> dict[str, object]:
+    def client_kwargs(self) -> AgamemnonClientKwargs:
         """Return keyword arguments for constructing an AgamemnonClient.
 
         Both ``cli.run`` and ``executor.run_workflow`` must use this so that


### PR DESCRIPTION
## Summary

- Introduce `AgamemnonClientKwargs` TypedDict in `config.py` matching `AgamemnonClient.__init__`'s exact parameter types (`str`/`bool` fields)
- Change `Settings.client_kwargs()` return type from `dict[str, object]` to `AgamemnonClientKwargs`
- Resolves 4 mypy `arg-type` errors in `executor.py:399` and `cli.py:178` where `**settings.client_kwargs()` was unpacked into `AgamemnonClient()`

## Test plan

- [x] `pixi run mypy src/telemachy --ignore-missing-imports` passes locally with no errors (was 4 errors before)
- [x] No other files changed — surgical fix only touching `config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)