### PR TITLE
fix(ci): markdownlint failures on main (CLAUDE.md, README.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ just format                        # ruff format
 ## Environment Variables
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
 | `AGAMEMNON_API_KEY` | `` | API key (if auth enabled) |
 | `NATS_URL` | `nats://localhost:4222` | NATS server URL for event monitoring |
@@ -136,4 +136,5 @@ just format                        # ruff format
 | `MONITOR_MAX_POLLS` | `7200` | Maximum polling attempts for workflow monitor |
 | `DEFAULT_WORKFLOW_TIMEOUT` | `7200` | Per-workflow execution timeout in seconds |
 
-<!-- triage: 2026-04-24 myrmidon-swarm implementation pass complete — 17 PRs merged, all remaining issues tracked individually -->
+<!-- triage: 2026-04-24 myrmidon-swarm implementation pass complete -->
+<!-- 17 PRs merged, all remaining issues tracked individually -->

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ teardown: on_completion   # on_completion | on_failure | never
 ### Agent Fields
 
 | Field | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `name` | required | Unique name within workflow |
 | `program` | `claude-code` | Agent program to run |
 | `model` | null | Override model (e.g. `claude-opus-4-5`) |


### PR DESCRIPTION
Fixes MD060 table-column-style and MD013 line-length violations reported by markdownlint-cli2 on main (run 25618353612).