### PR TITLE
chore: easy-issue sweep — refs #199 #200 #201 #193 #195

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ WorkflowExecutor
     ├── AgamemnonClient  →  POST /v1/agents/{id}/start   (start agents)
     ├── AgamemnonClient  →  POST /v1/teams               (create teams)
     ├── AgamemnonClient  →  POST /v1/teams/{id}/tasks    (create tasks)
-    ├── NATS subscriber  →  monitor task completion events
+    ├── NATS subscriber  →  monitor task completion events  (planned — not yet implemented)
     └── AgamemnonClient  →  DELETE /v1/agents/{id}       (teardown)
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ just validate workflows/example.yaml
 just status <workflow-id>
 ```
 
+> **Note:** `status`, `list`, and `cancel` are currently stubs. They print a
+> placeholder message because persistent workflow-state storage is not yet
+> implemented. Until a state backend lands, query ProjectAgamemnon directly
+> for live agent and team status.
+
 ## Workflow Schema
 
 A workflow YAML has four top-level sections:

--- a/src/telemachy/__init__.py
+++ b/src/telemachy/__init__.py
@@ -5,7 +5,7 @@ from telemachy.config import Settings
 from telemachy.executor import WorkflowExecutor
 from telemachy.models import AgentSpec, TaskSpec, TeamSpec, WorkflowSpec, WorkflowState
 
-version = "0.1.0"
+__version__ = "0.1.0"
 
 __all__ = [
     "WorkflowExecutor",

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class AgentSpec(BaseModel):
@@ -178,8 +178,9 @@ class WorkflowState(BaseModel):
     workflow_id: str
     spec: WorkflowSpec
     status: Literal["pending", "running", "completed", "failed", "cancelled"]
-    created_agents: dict[str, str] = {}  # agent name → agamemnon agent id
-    created_teams: dict[str, str] = {}   # team name → agamemnon team id
+    # Use default_factory to avoid sharing a mutable default across instances.
+    created_agents: dict[str, str] = Field(default_factory=dict)  # agent name → agamemnon agent id
+    created_teams: dict[str, str] = Field(default_factory=dict)   # team name → agamemnon team id
     started_at: str | None = None
     completed_at: str | None = None
     error: str | None = None

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -62,9 +62,13 @@ class TeamSpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_unique_task_subjects(self) -> TeamSpec:
-        subjects = [t.subject for t in self.tasks]
         seen: set[str] = set()
-        dupes = [s for s in subjects if s in seen or seen.add(s)]  # type: ignore[func-returns-value]
+        dupes: list[str] = []
+        for task in self.tasks:
+            if task.subject in seen:
+                dupes.append(task.subject)
+            else:
+                seen.add(task.subject)
         if dupes:
             raise ValueError(f"Duplicate task subjects in team {self.name!r}: {dupes}")
         return self


### PR DESCRIPTION
## Summary

Mechanical sweep of 5 minor audit findings. All changes are scoped, self-contained, and verified with the existing test suite.

| Issue | Type | Change |
| --- | --- | --- |
| #199 | refactor | `WorkflowState` mutable defaults → `Field(default_factory=dict)` |
| #200 | refactor | Replace `seen.add()` side-effect-in-comprehension with explicit loop |
| #201 | refactor | Rename module-level `version` → `__version__` (PEP 8) |
| #193 | docs | README notes that `status`/`list`/`cancel` are stubs |
| #195 | docs | CLAUDE.md architecture diagram marks NATS subscriber as planned |

`Refs #199 #200 #201 #193 #195` — partial fixes, per stall-rate guidance these are intentionally not `Closes`. Audit triage can verify and close.

## Diff size

- 4 files changed, 17 insertions(+), 7 deletions(-)
- Well under the 400 LOC scope cap.

## Verification

- `pixi run pytest tests/` — 42 passed
- `pixi run pytest tests/test_models.py -q` — 13 passed (covers both #199 and #200 paths)
- Grep confirmed no external callers of the renamed `version` symbol
- Grep confirmed `executor.py` imports no NATS module (justifies #195 doc fix)

## Per-issue notes

- **#199**: `WorkflowState` is a Pydantic `BaseModel`, so the literal `{}` was technically safe (Pydantic deep-copies defaults), but `Field(default_factory=dict)` is the documented best practice and removes any ambiguity.
- **#200**: The `# type: ignore[func-returns-value]` is removed as a side benefit.
- **#201**: Only declaration site exists; no `from telemachy import version` callers. Package-metadata `version` keys in `pyproject.toml` / `pixi.toml` are unrelated and untouched.
- **#193 / #195**: Pure doc updates — no behavior change.

## Out of scope (deferred)

- #202 (5 type:ignore — needs typing refactor)
- #203, #197, #198 (need new tests)
- #194 (ADR design work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)