### PR TITLE
chore: remove || true workarounds; add forbid-suppressions guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -11,6 +11,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              # Exempt this workflow file (heredoc would otherwise self-match)
+              .github/workflows/_required.yml) continue ;;
+              # Exempt any runbook that documents the rule (if present)
+              docs/runbooks/no-silent-failures.md) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found "continue-on-error: true" above. Fix the root cause per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   lint:
     name: lint
     runs-on: ubuntu-24.04
@@ -166,13 +217,20 @@ jobs:
           "
       - name: Validate workflow files against Telemachy schema
         run: |
-          pixi run python -m telemachy.cli schema > /tmp/telemachy-schema.json 2>/dev/null || true
-          if [ -f /tmp/telemachy-schema.json ]; then
+          set -euo pipefail
+          if pixi run python -m telemachy.cli schema > /tmp/telemachy-schema.json 2>/tmp/telemachy-schema.err; then
             pip install check-jsonschema --quiet
-            find workflows -name "*.yaml" -o -name "*.yml" | \
-              xargs check-jsonschema --schemafile /tmp/telemachy-schema.json || true
+            mapfile -t workflow_files < <(find workflows \( -name "*.yaml" -o -name "*.yml" \))
+            if [ "${#workflow_files[@]}" -eq 0 ]; then
+              echo "No workflow files to validate"
+            else
+              check-jsonschema --schemafile /tmp/telemachy-schema.json "${workflow_files[@]}"
+            fi
           else
-            echo "Schema export not available — YAML parse validation already passed above"
+            echo "::warning::Schema export failed; falling back to YAML parse validation only"
+            if [ -s /tmp/telemachy-schema.err ]; then
+              cat /tmp/telemachy-schema.err >&2
+            fi
           fi
 
   security-dependency-scan:
@@ -223,7 +281,6 @@ jobs:
             gitleaks detect --source . \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,3 @@ jobs:
             gitleaks detect --source . \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
           fi
-        continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,26 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. See HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true


### PR DESCRIPTION
## Summary

Ports the regression guard from [HomericIntelligence/Odysseus#280](https://github.com/HomericIntelligence/Odysseus/pull/280) and refactors all 4 silent-failure suppressions in this repo (2 `|| true`, 2 `continue-on-error: true`).

## Refactors

| File:line | Bucket | Before -> After |
| --- | --- | --- |
| `.github/workflows/_required.yml:169` | B (best-effort cleanup) | `schema > /tmp/... 2>/dev/null \|\| true` then `if [ -f ... ]` -> explicit `if pixi run ... schema > ... 2>err.log; then ... else echo ::warning::; cat err.log; fi`. Schema-export failures now visible. |
| `.github/workflows/_required.yml:173` | A (masks real failure) | `xargs check-jsonschema ... \|\| true` -> propagate failure; convert `find \| xargs` to `mapfile`+array so schema mismatches actually break CI. |
| `.github/workflows/_required.yml:226` | E (continue-on-error opt-out) | Removed `continue-on-error: true` on Gitleaks step (redundant: gitleaks already uses `--exit-code 0`, so the opt-out masked nothing real). |
| `.github/workflows/ci.yml:61` | E (continue-on-error opt-out) | Same as above for the secondary `ci.yml` Gitleaks step. |

## Regression guard

- **`.pre-commit-config.yaml`**: added `forbid-or-true` and `forbid-continue-on-error` pygrep hooks. Verified that planting `echo hi || true` makes `pre-commit run forbid-or-true` fail with the expected message.
- **`.github/workflows/_required.yml`**: added top-level `forbid-suppressions` job mirroring the runbook spec, with the same `.github/workflows/_required.yml` self-exemption.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on all three modified files: OK.
- `yamllint -c .yamllint.yaml` on the modified files: only one pre-existing `line-length` warning (line 60, unrelated to this PR).
- `pre-commit run --files .github/workflows/_required.yml .github/workflows/ci.yml .pre-commit-config.yaml`: all hooks pass.
- `grep -rnE '\|\|\s*true(...)' --include=*.{sh,bash,yml,yaml,hcl,Dockerfile*,*justfile}`: zero remaining matches.
- `grep -nE '^\s*continue-on-error:\s*true\s*$' .github/workflows/`: zero remaining matches.
- Regression sanity check: planted `echo hi || true` in a scratch file -> `forbid-or-true` correctly failed.

## Out of scope / pre-existing issues noticed but NOT fixed

- `pre-commit run --all-files` reports `ruff-format` failures on 7 unrelated Python files under `src/telemachy/` and `tests/` that are non-conforming on `main`. These are not part of this PR — reverted the auto-formatter changes to keep the diff focused. Should be addressed in a separate formatting PR.
- `.yamllint.yaml` line-length cap (120) is exceeded by line 60 of `_required.yml`, pre-existing.

## Test plan

- [ ] Required Checks workflow passes, including the new `forbid-suppressions` job.
- [ ] `pre-commit run --all-files` locally executes the two new hooks without surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)