### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 ProjectTelemachy is a declarative workflow engine that automates multi-agent workflows by calling the
 ProjectAgamemnon REST API. Users define workflows in YAML; Telemachy parses them, provisions agents and
-teams via Agamemnon, assigns tasks with dependency ordering, monitors execution via NATS events, and
+teams via Agamemnon, assigns tasks with dependency ordering, monitors execution by polling
+Agamemnon's REST API (NATS-based event monitoring is planned but not yet wired up), and
 tears down resources according to the workflow's teardown policy.
 
 **This project uses ProjectAgamemnon exclusively as its execution backend.**
@@ -69,7 +70,8 @@ teardown: on_completion | on_failure | never
 2. **Agamemnon exclusive** — never spawn agents directly; always call ProjectAgamemnon's REST API.
 3. **Idempotent teardown** — teardown is always safe to re-run; errors are logged but do not block.
 4. **Dependency-respecting** — tasks with `blocked_by` are not submitted until their predecessors complete.
-5. **Observable** — all state transitions are logged; NATS events drive completion detection.
+5. **Observable** — all state transitions are logged; completion is currently detected by HTTP
+   polling against Agamemnon (NATS event-driven completion is planned).
 6. **Type-safe** — all Python code uses type hints; Pydantic validates all external data.
 
 ## Repository Structure

--- a/justfile
+++ b/justfile
@@ -13,17 +13,17 @@ default:
 # Execute a workflow YAML file
 run WORKFLOW:
     AGAMEMNON_URL={{AGAMEMNON_URL}} NATS_URL={{NATS_URL}} \
-        pixi run python -m telemachy.cli run {{WORKFLOW}}
+        pixi run python -m telemachy.cli run "{{WORKFLOW}}"
 
 # Dry-run: show what would be created without executing
 plan WORKFLOW:
     AGAMEMNON_URL={{AGAMEMNON_URL}} NATS_URL={{NATS_URL}} \
-        pixi run python -m telemachy.cli plan {{WORKFLOW}}
+        pixi run python -m telemachy.cli plan "{{WORKFLOW}}"
 
 # Show status of a running workflow
 status WORKFLOW_ID:
     AGAMEMNON_URL={{AGAMEMNON_URL}} \
-        pixi run python -m telemachy.cli status {{WORKFLOW_ID}}
+        pixi run python -m telemachy.cli status "{{WORKFLOW_ID}}"
 
 # List all workflows (running and completed)
 list:
@@ -33,11 +33,11 @@ list:
 # Cancel a running workflow
 cancel WORKFLOW_ID:
     AGAMEMNON_URL={{AGAMEMNON_URL}} \
-        pixi run python -m telemachy.cli cancel {{WORKFLOW_ID}}
+        pixi run python -m telemachy.cli cancel "{{WORKFLOW_ID}}"
 
 # Validate a workflow YAML without executing
 validate WORKFLOW:
-    pixi run python -m telemachy.cli validate {{WORKFLOW}}
+    pixi run python -m telemachy.cli validate "{{WORKFLOW}}"
 
 # Export workflow JSON Schema for editor validation
 schema:

--- a/justfile
+++ b/justfile
@@ -53,9 +53,16 @@ test:
 lint:
     pixi run ruff check src tests
 
+# Run mypy static type checker
+mypy:
+    pixi run mypy src/telemachy --ignore-missing-imports
+
 # Format code with ruff
 format:
     pixi run ruff format src tests
+
+# Run the full local CI suite: lint, mypy, tests
+check: lint mypy test
 
 # Install dev dependencies and set up pre-commit hooks
 bootstrap:

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import httpx
 
 from telemachy.models import AgentSpec, TaskSpec
+
+logger = logging.getLogger(__name__)
 
 
 class AgamemnonError(Exception):
@@ -61,6 +64,15 @@ class AgamemnonClient:
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            # Empty AGAMEMNON_API_KEY silently disabled auth before #159 — log
+            # so production misconfiguration is visible in the daemon log.
+            logger.warning(
+                "AgamemnonClient initialised with empty api_key — "
+                "requests to %s will be UNAUTHENTICATED. Set AGAMEMNON_API_KEY "
+                "for any non-local environment.",
+                self._base_url,
+            )
         self._headers = headers
         self._client: httpx.AsyncClient | None = None
 

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -210,8 +210,15 @@ class AgamemnonClient:
         if assignee_agent_id is not None:
             payload["assigneeAgentId"] = assignee_agent_id
         elif spec.assign_to:
-            # Fallback: spec.assign_to should be an ID, not a name — callers must resolve
-            payload["assigneeAgentId"] = spec.assign_to
+            # spec.assign_to is a workflow-author-facing agent NAME, not an
+            # Agamemnon agent ID. Silently posting it as assigneeAgentId would
+            # produce a 4xx (or worse, an orphaned task) at runtime — fail fast
+            # so the caller is forced to resolve the name first (see #198).
+            raise ValueError(
+                f"Task {spec.subject!r} has assign_to={spec.assign_to!r} but no "
+                "assignee_agent_id was supplied. Callers must resolve the agent "
+                "name to an Agamemnon agent ID before invoking create_task()."
+            )
         if blocked_by_ids:
             payload["blockedBy"] = blocked_by_ids
 

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -45,6 +45,11 @@ class WorkflowExecutor:
             "on_workflow_complete": [],
             "on_workflow_failed": [],
         }
+        # Subjects of tasks for which we have already emitted a terminal event.
+        # Declared here (rather than lazily via getattr/setattr in _monitor_completion)
+        # so the attribute lifecycle is per-instance, statically typed, and fresh
+        # each execute() call starts with a clean set per executor.
+        self._emitted_task_events: set[str] = set()
 
     def add_hook(self, event: str, callback: Callable[..., Any]) -> None:
         """Register a callback for a workflow execution event.
@@ -69,6 +74,9 @@ class WorkflowExecutor:
 
     async def execute(self, spec: WorkflowSpec) -> WorkflowState:
         """Run a full workflow: provision → assign tasks → monitor → teardown."""
+        # Reset per-execution state so reusing the same executor for a second
+        # workflow does not leak emitted-event subjects from the prior run (#203).
+        self._emitted_task_events = set()
         timeout = spec.timeout_seconds if spec.timeout_seconds is not None else settings.default_workflow_timeout
         try:
             return await asyncio.wait_for(self._run(spec), timeout=timeout)
@@ -313,9 +321,10 @@ class WorkflowExecutor:
 
             all_done = True
             any_failed = False
-            # Track which tasks already emitted events to avoid duplicate callbacks
-            emitted_done: set[str] = getattr(self, "_emitted_task_events", set())
-            self._emitted_task_events: set[str] = emitted_done  # type: ignore[attr-defined]
+            # Track which tasks already emitted events to avoid duplicate callbacks.
+            # Backed by self._emitted_task_events (initialised in __init__,
+            # reset in execute()) — see #197 / #203.
+            emitted_done = self._emitted_task_events
 
             for team_name, team_id in state.created_teams.items():
                 tasks = await self._client.get_tasks(team_id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -167,14 +167,11 @@ class TestDependencyCycleDetection:
             team.detect_dependency_cycles()
 
     def test_self_dependency_raises(self) -> None:
+        # The self-dependency validator lives on TeamSpec.no_self_dependency;
+        # construct a TeamSpec containing the offending TaskSpec so the
+        # validator actually runs (the prior version of this test had an
+        # unreachable second TeamSpec(...) after the first raised — see #147).
         with pytest.raises(Exception, match="itself"):
-            TaskSpec(
-                subject="Task X",
-                description="...",
-                assign_to="a",
-                blocked_by=["Task X"],
-            )
-            # The validator runs at model level; construct TeamSpec to trigger it
             TeamSpec(
                 name="t",
                 agents=["a"],


### PR DESCRIPTION
## Summary

Bundle of small fixes from the 2026-05-11 ecosystem-wide easy-issue sweep on ProjectTelemachy.

## Implemented

- Closes #195 — `docs(claude)`: replace remaining "NATS events" claims (CLAUDE.md §Project Overview line 7 and §Key Principles item 5) with the actual HTTP-poll behaviour. Diagram annotation from #238 covered only one of three sites; this finishes the cleanup.
- Closes #197 — `refactor(executor)`: declare `_emitted_task_events: set[str]` in `__init__` (was lazily created via `getattr(self, ..., set())` / `setattr` inside `_monitor_completion`, requiring `# type: ignore[attr-defined]`).
- Closes #203 — `refactor(executor)`: reset `self._emitted_task_events` at the top of `execute()` so reusing one `WorkflowExecutor` across multiple workflows no longer leaks emitted-event subjects from a prior run. (Same commit as #197.)
- Closes #198 — `fix(client)`: in `AgamemnonClient.create_task`, raise `ValueError` instead of silently sending the workflow-author-facing agent NAME as `assigneeAgentId` when callers omit `assignee_agent_id`. The only in-tree caller already resolves names to IDs (#12), so behaviour is unchanged for valid usage; the latent bug now fails fast.
- Closes #181 — `fix(just)`: quote `{{WORKFLOW}}` / `{{WORKFLOW_ID}}` in the `run` / `plan` / `status` / `cancel` / `validate` recipes so workflow paths or IDs containing spaces survive shell expansion.
- Closes #184 — `feat(just)`: add `just mypy` recipe mirroring CI's `pixi run mypy src/telemachy --ignore-missing-imports`.
- Closes #183 — `feat(just)`: add composite `just check` recipe that chains `lint mypy test` for one-shot pre-push verification.
- Closes #159 — `fix(client)`: log a `WARNING` when `AgamemnonClient` is constructed with an empty `api_key`, instead of silently disabling authentication.
- Closes #147 — `test(models)`: drop the unreachable second `TeamSpec(...)` after the first `pytest.raises` block in `test_self_dependency_raises`. The validator lives on `TeamSpec`, so only the `TeamSpec` arm exercises it.

## Closed as ALREADY-DONE (no diff)

- Closes #199 — verified `created_agents` / `created_teams` use `Field(default_factory=dict)` (`src/telemachy/models.py:186-187`), landed in commit bdb1cb7 with "Refs #199".
- Closes #200 — verified duplicate-detection in `validate_unique_task_subjects` uses an explicit for-loop (`src/telemachy/models.py:64-74`), no list-comprehension side-effects, landed in commit bdb1cb7.
- Closes #201 — verified `__version__` is exposed from `src/telemachy/__init__.py:8`, landed in commit bdb1cb7.
- Closes #193 — verified README Quick Start now explicitly notes that `status` / `list` / `cancel` are stubs (`README.md:35-38`), landed in commit bdb1cb7.
- Closes #182 — verified `.env.example` documents all 10 fields exposed by `Settings`, landed in commit fc51056.

## BLOCKED — too large for a 50-LoC sweep

Skipped without commits; left for dedicated follow-up work.

- #202 — removing 5 `# type: ignore` annotations needs typed `dict[str, Any]` schema work in `agamemnon_client.py` and `cli.py`.
- #194 — write 2+ ADRs (HTTP polling decision, maestro deprecation).
- #187 — design and implement workflow audit-trail.
- #186 — add GDPR/privacy section spanning multiple docs.
- #185, #156 — formal license-compatibility audit.
- #180, #155 — add macOS / Windows pixi targets (cross-platform validation needed).
- #179 — write backwards-compatibility policy.
- #178 — author install/upgrade documentation.
- #175 — author CLAUDE.md agent guardrails section.
- #174, #173, #172 — design and implement custom skills, MCP server config, AGENTS.md.
- #170, #169, #168 — process docs (Definition of Done, release management, PR template fields).
- #166 — implement concurrency limit on agent provisioning (semaphore + tests).
- #165 — add 429 handling to `_request_with_retry`.
- #164 — orphan-recovery on partial provisioning failure (already partially mitigated; needs design).
- #160 — token-bucket / throttle for burst API calls.
- #158 — flip `require_tls` default to `True` (breaking change; needs migration plan).
- #154 — `nats-py` is unused but CLAUDE.md still lists NATS as planned; removal would conflict with that roadmap.
- #153 — release/deployment workflow.
- #152, #148 — coverage minimum threshold (needs current baseline + ratchet plan).
- #151 — deduplicate `ci.yml` and `_required.yml` (impacts required checks; risky as solo PR).
- #150 — refactor schema-validation step to fail fast (the `|| true` literal was already removed in #239; the if/else fallback still swallows but rewriting it cleanly is a larger CI design change).
- #149 — convert YAML test fixtures to parameterized factories.
- #42 — remove CLI stub commands (status/list/cancel) — interacts with documented public surface (#193).

## Test plan

- [x] `pixi run pytest` — 42 passed
- [x] `pixi run mypy src/telemachy --ignore-missing-imports` — Success
- [x] `pixi run ruff check src tests` — All checks passed
- [x] `pre-commit run --files <changed-files>` — Passed (excluding pre-existing ruff-format reflow on unrelated lines, which CI does not enforce).