### PR TITLE
chore: easy-issue sweep bundle (2026-05-16)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,39 @@
+# ProjectTelemachy Custom Skills
+
+This directory holds repository-specific Claude / Hephaestus skills for
+ProjectTelemachy-specific workflows. Skills are markdown documents that
+describe **how to perform a recurring task** in this repository; they
+complement the global Hephaestus skill library by capturing knowledge
+that is too narrow for ecosystem-wide reuse.
+
+## Conventions
+
+- One skill per file: `<verb-noun>.md` (e.g., `validate-workflow.md`).
+- Each skill begins with a one-line summary and a "Use when" trigger
+  list, matching the Hephaestus skill format.
+- Skills are executable as `Read`-and-follow procedures; they must not
+  contain any side-effecting code that runs on load.
+- New skills are reviewed in pull requests like any other change.
+
+## Index
+
+(Empty — see `docs/ROADMAP.md` for the first scheduled skill additions.)
+
+## Suggested skills
+
+These are tracked as work items and may live here once authored:
+
+- `validate-workflow.md` — guided procedure for running
+  `just validate` against a workflow YAML, including expected error
+  shapes.
+- `add-workflow-example.md` — procedure for adding a new workflow
+  example under `workflows/`, with the Definition-of-Done checklist.
+- `bump-version.md` — automation-friendly procedure walking through
+  the three version sources of truth (`pyproject.toml`,
+  `src/telemachy/__init__.py`, `CHANGELOG.md`).
+
+## See also
+
+- `~/.claude/skills/` — user-global skills.
+- Hephaestus plugin skills enabled via `.claude/settings.json`.
+- `docs/definition-of-done.md` — the standard a skill output must meet.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,40 @@
 ## Summary
 
-<!-- What does this PR do? -->
+<!-- What does this PR do? Why? One or two sentences. -->
 
 ## Related issues
 
-<!-- Closes #N -->
+<!-- Closes #N / Refs #N. List one per line. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change (workflow YAML, CLI, or `telemachy.*` public API)
+- [ ] Documentation only
+- [ ] CI / tooling
+
+## Reviewers, labels, milestone
+
+<!--
+Suggested reviewer(s):  @
+Suggested label(s):      bug | enhancement | docs | chore | breaking-change
+Suggested milestone:     v0.x.y  (see docs/ROADMAP.md if present)
+
+These are hints for the PR author; the actual assignment is done via
+the GitHub UI sidebar after the PR is opened.
+-->
 
 ## Test plan
 
-- [ ] Tests pass (`just test`)
-- [ ] Linting passes (`just lint`)
-- [ ] Tested locally with `just validate workflows/example.yaml`
+- [ ] Tests pass (`just test`).
+- [ ] Linting passes (`just lint`).
+- [ ] Tested locally with `just validate workflows/example.yaml`.
+- [ ] New conditional branches have new tests (see `docs/definition-of-done.md`).
+- [ ] `CHANGELOG.md` `Unreleased` entry added if user-visible.
+
+## Risk and rollout
+
+- Backwards compatible: yes / no
+- Requires schema bump (`apiVersion`): yes / no
+- Requires CI / branch-protection changes: yes / no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ off (see "Handoff" below).
 ## Role boundaries
 
 | Agent | Owns | Must not do |
-|---|---|---|
+| --- | --- | --- |
 | ProjectTelemachy | workflow YAML interpretation, dependency ordering, teardown policy | spawn agents directly (always via Agamemnon) |
 | ProjectAgamemnon | agent / team / task lifecycle, HMAS orchestration | parse workflow YAML |
 | ProjectNestor | research and ideation upstream | execute workflows |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md — ProjectTelemachy
+
+This document specifies the multi-agent coordination protocols for
+ProjectTelemachy within the HomericIntelligence distributed agent mesh.
+
+## Role
+
+ProjectTelemachy is the declarative workflow engine: it parses YAML
+workflows, provisions agents and teams via ProjectAgamemnon's REST API,
+assigns dependency-ordered tasks, monitors completion, and tears down
+resources.
+
+```
+Workflow YAML
+    │
+    ▼
+WorkflowSpec ──► WorkflowExecutor ──► ProjectAgamemnon REST API
+                                     ▲
+                                     └─ provisions agents/teams/tasks
+```
+
+Telemachy is the **only** agent authorised to translate declarative
+workflow YAML into Agamemnon API calls. Other agents must not bypass
+Telemachy to provision Agamemnon resources unless explicitly handing
+off (see "Handoff" below).
+
+## Role boundaries
+
+| Agent | Owns | Must not do |
+|---|---|---|
+| ProjectTelemachy | workflow YAML interpretation, dependency ordering, teardown policy | spawn agents directly (always via Agamemnon) |
+| ProjectAgamemnon | agent / team / task lifecycle, HMAS orchestration | parse workflow YAML |
+| ProjectNestor | research and ideation upstream | execute workflows |
+| ProjectArgus | observability, log aggregation | mutate state in Agamemnon |
+| ProjectHermes | NATS event bridge | own agent lifecycle |
+
+## Handoff contract
+
+- **Inbound:** users (or ProjectNestor) deliver workflow YAML through the
+  Typer CLI (`just run <file>`) or via library use of
+  `telemachy.executor.WorkflowExecutor`.
+- **Outbound:** Telemachy calls Agamemnon REST endpoints in the order
+  documented in `CLAUDE.md`. The handoff payload to Agamemnon is the
+  AgentSpec / TeamSpec / TaskSpec record validated by
+  `telemachy.models`.
+
+## Inter-agent message contracts
+
+- All Agamemnon HTTP calls use `httpx.AsyncClient`; payloads conform to
+  ProjectAgamemnon's published OpenAPI shape.
+- Future NATS-based completion monitoring will subscribe to subjects
+  documented in Odysseus `docs/adr/005-nats-subject-schema.md`. Until
+  that lands Telemachy polls Agamemnon via HTTP.
+
+## Coordination invariants
+
+1. **Agamemnon exclusive.** Telemachy never spawns processes,
+   containers, or agents itself.
+2. **Dependency-respecting.** Tasks with `blocked_by` are not submitted
+   until predecessors complete.
+3. **Idempotent teardown.** Re-running teardown for an already-torn-down
+   workflow is a no-op.
+4. **Pure planning.** `just plan` and `just validate` never mutate
+   Agamemnon state.
+
+## See also
+
+- `CLAUDE.md` — single-agent operational conventions and guardrails.
+- `CONTRIBUTING.md` — contribution workflow.
+- Odysseus `docs/adr/005-nats-subject-schema.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,32 @@ ProjectTelemachy/
 - Errors from Agamemnon should raise typed exceptions, not generic ones.
 - Tests use `pytest-asyncio` and mock the `AgamemnonClient` at the boundary.
 
+## Agent Guardrails
+
+AI agents (Claude, Myrmidon swarm, automation) working in this repository must
+obey the following hard rules. These guardrails apply on top of the rest of
+this document, the project's `CONTRIBUTING.md`, and the user's per-machine
+memory.
+
+- **Never commit directly to `main`.** All changes flow through pull requests.
+- **Never `--admin` merge.** Squash-merge through GitHub UI or `gh pr merge --auto --squash` only.
+- **Never delete branches with `git branch -d/-D`.** Use a different branch name instead.
+- **Never delete a running agent or team via Agamemnon.** Always follow the
+  workflow's declared `teardown` policy (`on_completion`, `on_failure`,
+  `never`) — never short-circuit it from an agent shell.
+- **Always `just plan` before `just run`** on a workflow you didn't author.
+- **Always `just validate` before opening a PR** that touches a workflow YAML.
+- **Never bypass `pre-commit`** unless the brief explicitly authorises
+  `--no-verify` (it stalls on cold worktrees; document the bypass in the
+  PR body).
+- **Never write to `pixi.lock` by hand;** regenerate via `pixi install`.
+- **Workflow YAML is a public API** — any change to required fields,
+  default values, or schema constraints requires a `MINOR` (additive) or
+  `MAJOR` (breaking) version bump per `docs/backwards-compat.md`.
+
+If a task appears to require violating one of the rules above, stop and
+open an issue describing the conflict before proceeding.
+
 ## Common Commands
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing ProjectTelemachy
+
+This document describes the **manual** release process for
+ProjectTelemachy. Automation is tracked in the issue backlog.
+
+## Version sources of truth
+
+Versions appear in:
+
+1. `pyproject.toml` — `version` (canonical).
+2. `src/telemachy/__init__.py` — `__version__` constant.
+3. `CHANGELOG.md` — `## [X.Y.Z] - YYYY-MM-DD` heading.
+
+All three must agree at release time. A CI sync check exists (see
+`workflows/`) but is currently advisory; the release author is responsible
+for keeping them aligned.
+
+## Versioning policy
+
+ProjectTelemachy follows [Semantic Versioning 2.0.0](https://semver.org/).
+The public surface area governed by SemVer is:
+
+- The **workflow YAML schema** (`apiVersion: telemachy/v1`, field names,
+  field types, default values).
+- The Typer CLI subcommand contract (`run`, `plan`, `status`, `validate`,
+  `list`, `cancel`) — names and required arguments.
+- Public Python imports under `telemachy.*` (executor, models, config).
+
+Internal: HTTP client retry tuning, monitor poll interval defaults,
+logging output, and test fixtures are **not** public API.
+
+While the version remains `0.y.z` the workflow schema may receive
+breaking changes in any `MINOR` bump; operators should pin a specific
+`MINOR` until v1.0.0.
+
+## Release procedure
+
+1. Decide the bump kind (`MAJOR`, `MINOR`, `PATCH`).
+2. Update the three version sources above in a single commit:
+   `chore(release): bump version to X.Y.Z`.
+3. Update `CHANGELOG.md`:
+   - Move accumulated `## [Unreleased]` entries under
+     `## [X.Y.Z] - YYYY-MM-DD`.
+   - Add a fresh empty `## [Unreleased]` block above.
+4. Open a PR titled `chore(release): X.Y.Z`.
+5. After squash-merge, create an annotated git tag on the squash commit:
+   `git tag -a vX.Y.Z -m "Release X.Y.Z"` and push it.
+6. Create a matching GitHub Release referencing the `CHANGELOG.md` entry.
+7. Announce the release in the Odysseus integration channel.
+
+## Who approves
+
+A release PR requires at least one CODEOWNERS approval. The release
+author is responsible for verifying CI green before tagging.
+
+## Hot-fixes
+
+For patch releases off a previous `MINOR`:
+
+1. Branch from the last `vX.Y.0` tag as `release/X.Y`.
+2. Cherry-pick (or re-author) the minimal fix; bump `PATCH`.
+3. Tag `vX.Y.Z+1` from the release branch.
+4. Forward-port the fix to `main` in a separate PR.

--- a/docs/adr/001-http-polling-monitoring.md
+++ b/docs/adr/001-http-polling-monitoring.md
@@ -1,0 +1,65 @@
+# ADR-001: Monitor workflow completion via HTTP polling
+
+- **Status:** Proposed
+- **Date:** 2026-05-16
+- **Deciders:** ProjectTelemachy maintainers
+- **Context tags:** monitoring, NATS, executor
+
+## Context
+
+ProjectTelemachy's `WorkflowExecutor` needs to detect when assigned tasks
+complete, so it can release dependent tasks and ultimately tear the
+workflow down per the declared teardown policy.
+
+Two approaches were available:
+
+1. **NATS event subscription** — subscribe to completion events emitted by
+   ProjectAgamemnon. Real-time, low overhead, but requires a NATS broker
+   reachable from the Telemachy host and adds an asynchronous dependency
+   on a separate transport.
+2. **HTTP polling** — repeatedly call ProjectAgamemnon's REST API to query
+   task state. Higher latency and overhead, but uses the same transport
+   already required for provisioning, so no new infrastructure or library
+   needs to be wired up.
+
+`CLAUDE.md` describes NATS as "planned but not yet wired up"; `nats-py`
+is declared as a dependency but not imported. The initial implementation
+chose HTTP polling.
+
+## Decision
+
+ProjectTelemachy monitors task completion by polling
+ProjectAgamemnon's REST API at the interval defined by
+`MONITOR_TIMEOUT_SECONDS` / `MONITOR_MAX_POLLS`. The NATS-based monitor
+path remains aspirational and is tracked by repository issues; this ADR
+will be superseded when a NATS-based design is accepted.
+
+## Consequences
+
+Positive:
+
+- One transport (HTTP) for all Agamemnon interactions; simpler
+  deployment.
+- No NATS broker required on the Telemachy host.
+- Easier testing — the executor is straightforward to mock against
+  `httpx.AsyncClient`.
+
+Negative:
+
+- Completion latency is bounded below by the poll interval.
+- Wasted requests when nothing has changed.
+- Adds load on ProjectAgamemnon proportional to the number of in-flight
+  workflows.
+
+## Alternatives considered
+
+- Subscribe directly to NATS via `nats-py`. Rejected for the initial
+  release because the broker contract was not stable across the
+  ecosystem at the time. Revisit when ADR-005 in Odysseus (subject
+  schema) is fully adopted by Agamemnon.
+
+## References
+
+- `src/telemachy/executor.py` (poll loop)
+- `src/telemachy/agamemnon_client.py`
+- Odysseus `docs/adr/005-nats-subject-schema.md`

--- a/docs/adr/002-decouple-from-maestro.md
+++ b/docs/adr/002-decouple-from-maestro.md
@@ -1,0 +1,54 @@
+# ADR-002: Decouple from ai-maestro; use ProjectAgamemnon exclusively
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Deciders:** ProjectTelemachy maintainers
+- **Context tags:** orchestration, Agamemnon, maestro
+
+## Context
+
+ProjectTelemachy originally supported two backends:
+
+1. ai-maestro — the previous orchestrator in the HomericIntelligence
+   ecosystem (see Odysseus `docs/adr/006-decouple-from-ai-maestro.md`).
+2. ProjectAgamemnon — the current planning + HMAS orchestration service.
+
+Maintaining two backends doubled the surface area of
+`agamemnon_client.py` / `maestro_client.py` and pushed schema decisions
+upstream into the workflow YAML. Per the Odysseus ecosystem-level ADR-006,
+ai-maestro has been removed from the mesh.
+
+## Decision
+
+ProjectTelemachy targets **ProjectAgamemnon exclusively** as its execution
+backend. The `maestro_client.py` module is retained only as a thin
+deprecation stub and will be removed in a future major release.
+
+All new code paths must go through `agamemnon_client.py`. New features
+that imply a backend change must add a new ADR superseding this one.
+
+## Consequences
+
+Positive:
+
+- Single client to test and document.
+- Clear handoff contract documented in `AGENTS.md`.
+- Aligns with Odysseus ADR-006.
+
+Negative:
+
+- No fallback if Agamemnon is unreachable; Telemachy fails closed.
+- Migration path required for any caller still depending on the
+  maestro-shaped contract (handled via deprecation warnings during the
+  pre-1.0 window).
+
+## Alternatives considered
+
+- Keep both backends behind a feature flag. Rejected — increases the
+  testing matrix and conflicts with Odysseus ADR-006.
+
+## References
+
+- `CLAUDE.md` — describes Agamemnon-exclusive execution.
+- Odysseus `docs/adr/006-decouple-from-ai-maestro.md`.
+- `src/telemachy/maestro_client.py` (deprecation stub).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for
+ProjectTelemachy. ADRs are append-only documents capturing **why** a
+significant architectural choice was made.
+
+## Convention
+
+- ADRs are numbered sequentially: `001-<slug>.md`, `002-<slug>.md`, …
+- Use `template.md` as the starting point.
+- New ADRs are *Proposed* until merged; once accepted they are never
+  edited. Superseding decisions get a new ADR that references the old.
+- The format mirrors the Odysseus meta-repo's ADR convention.
+
+## Index
+
+| Number | Title | Status |
+|---|---|---|
+| 001 | Monitoring via HTTP polling instead of NATS events | Proposed |
+| 002 | Decouple from ai-maestro (use Agamemnon exclusively) | Accepted |
+
+## See also
+
+- `docs/backwards-compat.md`
+- Odysseus `docs/adr/` (ecosystem-wide ADRs)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@ significant architectural choice was made.
 ## Index
 
 | Number | Title | Status |
-|---|---|---|
+| --- | --- | --- |
 | 001 | Monitoring via HTTP polling instead of NATS events | Proposed |
 | 002 | Decouple from ai-maestro (use Agamemnon exclusively) | Accepted |
 

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,9 +1,9 @@
-# ADR-NNN: <Title>
+# ADR-NNN: `Title`
 
 - **Status:** Proposed | Accepted | Superseded by ADR-MMM
 - **Date:** YYYY-MM-DD
-- **Deciders:** <names>
-- **Context tags:** <area>
+- **Deciders:** `names`
+- **Context tags:** `area`
 
 ## Context
 

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,31 @@
+# ADR-NNN: <Title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-MMM
+- **Date:** YYYY-MM-DD
+- **Deciders:** <names>
+- **Context tags:** <area>
+
+## Context
+
+What is the issue motivating this decision? Include relevant constraints,
+prior art, and the state of the world before this decision.
+
+## Decision
+
+What is the chosen approach? Be specific; this is the load-bearing
+sentence of the ADR.
+
+## Consequences
+
+Positive and negative consequences. What does this make easier? What
+becomes harder or impossible? What is the rollback story?
+
+## Alternatives considered
+
+Briefly summarise the alternatives and why each was rejected.
+
+## References
+
+- Related ADRs
+- Issues / PRs
+- External documentation

--- a/docs/backwards-compat.md
+++ b/docs/backwards-compat.md
@@ -1,0 +1,81 @@
+# Backwards Compatibility Policy
+
+This document defines what backwards compatibility means for
+ProjectTelemachy and how breaking changes are handled.
+
+## Public surface area (governed by SemVer)
+
+The following surfaces follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+1. **Workflow YAML schema** — the structure validated by
+   `telemachy.models.WorkflowSpec`:
+   - `apiVersion`, `metadata`, `agents`, `teams`, `tasks`, `teardown` fields.
+   - Required versus optional status of each field.
+   - Default values applied when a field is omitted.
+   - Allowed values for enumerated fields (e.g., `runtime`, `teardown`).
+2. **Typer CLI** — the subcommand names, required arguments, and exit codes
+   for `run`, `plan`, `status`, `validate`, `list`, `cancel`.
+3. **Python public API** — names exported from `telemachy/__init__.py` and
+   `telemachy.executor`, `telemachy.models`, `telemachy.config`.
+4. **Environment variables** — names and defaults documented in `CLAUDE.md`.
+
+## Not public
+
+- Internal HTTP retry / poll tuning constants.
+- Logging format and verbosity defaults.
+- Test fixtures, internal `_`-prefixed helpers, anything inside
+  `telemachy/_internal/` (if such a package is introduced).
+- The exact wording of CLI output (only its structure and exit code).
+
+## What counts as breaking
+
+A change is **breaking** (requires `MAJOR` bump, or pre-1.0 `MINOR` bump) if it:
+
+- Removes or renames a field on the workflow schema.
+- Changes the default value of a field in a way that changes runtime behaviour.
+- Tightens the allowed values of an enumerated field.
+- Adds a new **required** field to the workflow schema.
+- Renames or removes a CLI subcommand, required argument, or supported flag.
+- Removes a symbol from the Python public API or changes its signature.
+- Renames or removes a documented environment variable.
+
+A change is **non-breaking** if it:
+
+- Adds a new optional field to the workflow schema with a sensible default.
+- Adds a new CLI subcommand or optional flag.
+- Adds a new Python public symbol.
+- Adds a new environment variable with a default.
+
+## Deprecation policy
+
+Before removing or renaming a public surface:
+
+1. Mark the surface as deprecated in a `MINOR` (or `PATCH` if pre-1.0)
+   release. Emit a `DeprecationWarning` for Python symbols; log a `WARNING`
+   for CLI usage; for workflow schema, log a `WARNING` on `validate`.
+2. Add a `### Deprecated` entry in `CHANGELOG.md` and document the
+   replacement.
+3. Keep the deprecated surface working for **at least one minor release**
+   before removal.
+4. Remove in the next `MAJOR` release (or pre-1.0 `MINOR` release).
+
+## Migration guide template
+
+When a breaking change ships, the `CHANGELOG.md` entry must include:
+
+```markdown
+### Changed (breaking)
+
+- `<surface>` — what changed, why, and how to migrate.
+  - Before: <example>
+  - After:  <example>
+```
+
+A standalone migration document is added under `docs/migrations/X.Y.md`
+when the migration is non-trivial (more than 5 lines of guidance).
+
+## Pre-1.0 caveat
+
+While the version remains `0.y.z`, the workflow schema may receive
+breaking changes in any `MINOR` bump. Operators should pin a specific
+`MINOR` until v1.0.0.

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -1,0 +1,44 @@
+# Definition of Done
+
+This document captures what "done" means for a feature, bug-fix, or
+documentation change in ProjectTelemachy. It complements `CONTRIBUTING.md`.
+
+## Done — feature
+
+- [ ] Pydantic models / workflow schema updated (if applicable).
+- [ ] `pytest` covers each new conditional branch (positive + negative).
+- [ ] `just lint` and `just format-check` clean.
+- [ ] Public API change documented in `README.md` and `CLAUDE.md`.
+- [ ] If workflow YAML schema changes: bump `apiVersion` per
+      `docs/backwards-compat.md` and update workflow examples.
+- [ ] `CHANGELOG.md` `Unreleased` entry added (one bullet, user-facing language).
+- [ ] PR description links the issue with `Closes #N`.
+- [ ] At least one approving review (per CODEOWNERS / branch protection).
+- [ ] CI green (required checks listed in `.github/`).
+
+## Done — bug fix
+
+- [ ] Regression test added that fails before the fix and passes after.
+- [ ] `CHANGELOG.md` `Unreleased` entry under `### Fixed`.
+- [ ] Root cause documented in the PR description.
+- [ ] If the bug was a contract drift with Agamemnon, an ADR or note is
+      added under `docs/`.
+
+## Done — documentation
+
+- [ ] Markdown lint passes (`just lint` / pre-commit `markdownlint`).
+- [ ] Links resolve (relative paths checked locally).
+- [ ] If the doc changes a policy (release, backwards compat, retention),
+      reference it from `CONTRIBUTING.md`.
+
+## Done — CI / tooling
+
+- [ ] Workflow runs successfully on the PR.
+- [ ] Required check list in branch protection updated if a job was
+      renamed/added.
+- [ ] Time and resource impact noted in the PR description.
+
+## Not done
+
+A PR that fails any of the above is *Not Done*. Reviewers should request
+changes rather than merge with TODOs.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,87 @@
+# Installing and Upgrading ProjectTelemachy
+
+ProjectTelemachy is a Python package distributed primarily for the
+HomericIntelligence ecosystem. This document explains how to install it
+outside the pinned `pixi` development environment.
+
+## Supported installation modes
+
+### 1. `pixi` (development; recommended)
+
+```bash
+git clone https://github.com/HomericIntelligence/ProjectTelemachy.git
+cd ProjectTelemachy
+pixi install
+pixi run just test
+```
+
+This is the only installation path covered by CI and the test suite.
+
+### 2. `pip install --editable .` (contributor outside pixi)
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+```
+
+Use this when you cannot install `pixi` (e.g., on a restricted host).
+You are responsible for matching the Python and dependency versions
+declared in `pyproject.toml`; CI does not run this path.
+
+### 3. `pip install` from a release tag (operator)
+
+```bash
+pip install "git+https://github.com/HomericIntelligence/ProjectTelemachy@vX.Y.Z"
+```
+
+This installs the `telemachy` CLI and library into the active Python
+environment. Pin the tag exactly — `main` may carry unreleased schema
+changes.
+
+### 4. As a library dependency (downstream Python project)
+
+Add to your `pyproject.toml`:
+
+```toml
+[project]
+dependencies = [
+    "telemachy @ git+https://github.com/HomericIntelligence/ProjectTelemachy@vX.Y.Z",
+]
+```
+
+Pin to a specific tag, not a branch.
+
+## Upgrading
+
+1. Read `CHANGELOG.md` between your current version and the target
+   version, paying attention to the `### Changed`, `### Removed`, and
+   `### Deprecated` sections.
+2. Read `docs/backwards-compat.md` to determine whether the upgrade
+   crosses a breaking-change boundary.
+3. If crossing a breaking boundary, follow the migration steps in the
+   relevant CHANGELOG entry.
+4. Upgrade in a non-production environment first; run
+   `just validate workflows/<your>.yaml` to confirm the workflow still
+   parses.
+
+## Uninstalling
+
+```bash
+pip uninstall telemachy            # if installed via pip
+# or remove the pixi-managed checkout directory
+rm -rf <repo-checkout>/.pixi
+```
+
+No persistent data is stored by ProjectTelemachy itself — workflow state
+lives in ProjectAgamemnon.
+
+## Troubleshooting
+
+- **`No module named telemachy`** — confirm the active environment
+  matches the installation mode above.
+- **CLI commands hang** — confirm `AGAMEMNON_URL` is reachable; see the
+  env vars table in `CLAUDE.md`.
+- **`Workflow schema validation failed`** — run `just validate` to get
+  the structured error, and consult `docs/backwards-compat.md` if the
+  workflow worked on a previous version.

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -1,0 +1,61 @@
+# Dependency License Compatibility Audit
+
+ProjectTelemachy is distributed under the MIT License (see `LICENSE`).
+This document records the formal license audit of runtime dependencies
+to confirm distribution compatibility.
+
+## Audit date
+
+2026-05-16
+
+## Method
+
+1. Enumerate runtime dependencies from `pyproject.toml` and `pixi.toml`
+   `[pypi-dependencies]`.
+2. Resolve each dependency's declared license from its PyPI metadata
+   and source distribution.
+3. Compare each license against the MIT distribution model — any
+   permissive license (MIT, BSD, ISC, Apache 2.0) is compatible;
+   weakly-copyleft licenses (LGPL) require dynamic linking only;
+   strong-copyleft (GPL, AGPL) is incompatible.
+
+## Findings
+
+| Dependency | License | Compatible with MIT distribution? |
+|---|---|---|
+| `httpx` | BSD-3-Clause | yes |
+| `pydantic` | MIT | yes |
+| `pydantic-settings` | MIT | yes |
+| `typer` | MIT | yes |
+| `rich` | MIT | yes |
+| `pyyaml` | MIT | yes |
+| `nats-py` | Apache-2.0 | yes |
+
+All declared runtime dependencies are permissively licensed and
+compatible with redistribution under MIT.
+
+## Notes
+
+- `nats-py` is currently declared but unused in code (see issues
+  #154 / #196). Once removed it can be dropped from this table.
+- Apache-2.0 dependencies retain their attribution requirements; any
+  redistribution of ProjectTelemachy source or binaries must preserve
+  the upstream `LICENSE` and `NOTICE` files for those dependencies.
+  (Standard pip-installed dependencies are not redistributed by us;
+  they remain on PyPI under their own terms.)
+- Development-only dependencies (`pytest`, `ruff`, `pre-commit`) are
+  not audited here because they do not ship in the runtime artifact.
+
+## Re-audit cadence
+
+This audit is re-run:
+
+1. When a runtime dependency is added.
+2. When a runtime dependency's major version is bumped.
+3. Annually if neither of the above has occurred.
+
+## See also
+
+- `LICENSE`
+- `pyproject.toml` `[project] dependencies`
+- `docs/backwards-compat.md` — separately governs API compatibility

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -22,7 +22,7 @@ to confirm distribution compatibility.
 ## Findings
 
 | Dependency | License | Compatible with MIT distribution? |
-|---|---|---|
+| --- | --- | --- |
 | `httpx` | BSD-3-Clause | yes |
 | `pydantic` | MIT | yes |
 | `pydantic-settings` | MIT | yes |


### PR DESCRIPTION
## Summary

Bundled easy-issue sweep for ProjectTelemachy as part of the 2026-05-16 ecosystem-wide easy-sweep wave. All 10 issues are documentation-only additions surfaced by the 2026-04-28 strict-audit epic (#92). One commit per issue; bisect-friendly if CI flags anything.

## Bundled fixes

| Issue | Commit | One-line |
|---|---|---|
| #175 | `a7e6b8c` | docs(claude): add explicit agent guardrails section to CLAUDE.md |
| #172 | `29bb9bd` | docs(agents): add AGENTS.md describing multi-agent coordination protocols |
| #170 | `5ce66ec` | docs(dod): add Definition of Done for features, fixes, docs, CI |
| #169 | `49e7629` | docs(release): document manual release process and versioning policy |
| #168 | `24fd978` | docs(github): add reviewers/labels/milestone hints to PR template |
| #178 | `ae1b40f` | docs(install): document pip/library install paths beyond pixi setup |
| #179 | `085375a` | docs(compat): add backwards compatibility policy and deprecation rules |
| #185 | `8357d5a` | docs(license): add formal dependency license compatibility audit |
| #194 | `fb57e40` | docs(adr): scaffold docs/adr/ with README, template, and ADR-001/002 |
| #174 | `991669b` | docs(skills): scaffold .claude/skills/ with index and conventions |

## Policy

Per `ecosystem-wide-easy-sweep` skill v1.0.0:

- **Squash-only.** This repo, like all HomericIntelligence repos, is squash-only.
- **Review required.** Do NOT use `--admin` to bypass. Do NOT enable auto-merge; bundled PRs require human review.
- **No auto-merge.** Reviewers should land this after a normal review pass.
- One commit per issue inside the bundle so a single bad commit can be reverted without dropping the bundle.

## Stale-check closures

None. All 10 EASY candidates verified open via `gh issue view --comments`; no ALREADY_DONE matches found.

## Quirks honored / discovered

- `CHANGELOG.md` empirically verified **present** via GitHub Contents API (200 OK). The classifier's note that Telemachy's CHANGELOG was not policy-deleted is confirmed; no CHANGELOG-related auto-close was attempted in this bundle.
- `pre-commit` + `markdownlint` + `yamllint` + pixi + justfile + CLAUDE.md present as expected. `--no-verify` used on every commit per the brief.
- `.claude/skills/` previously empty; this bundle adds an index + conventions doc rather than authoring any concrete skill (skill authoring is MEDIUM work).
- ADR-001 (HTTP polling monitoring) is filed as **Proposed** rather than Accepted, because the maintainer may want to substantively edit the decision before accepting; ADR-002 (Agamemnon-exclusive) is **Accepted** because the underlying decision is already enforced in code and documented in `CLAUDE.md`.

Branch cut from `origin/main` at clean state.
