### PR TITLE
docs: correct NATS-monitoring drift across CLAUDE.md/README/CONTRIBUTING

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -250,7 +250,8 @@ jobs:
           pixi run python -c "
           import importlib.metadata, sys
           dists = importlib.metadata.distributions()
-          lines = [f'{d.metadata[\"Name\"]}=={d.metadata[\"Version\"]}' for d in dists]
+          lines = [f'{d.metadata[\"Name\"]}=={d.metadata[\"Version\"]}' for d in dists
+                   if d.metadata.get('Name') and d.metadata.get('Version')]
           sys.stdout.write('\n'.join(lines) + '\n')
           " | grep -viE '^telemachy==' > /tmp/requirements-freeze.txt
           pip-audit -r /tmp/requirements-freeze.txt --skip-editable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,13 @@ WorkflowExecutor
     └── AgamemnonClient  →  DELETE /v1/agents/{id}       (teardown)
 ```
 
-_Planned (issue #92): a NATS subscriber consuming Agamemnon task-lifecycle events will replace the HTTP polling loop in `_monitor_completion`. Not yet implemented._
+_Planned (issue #92): a NATS subscriber consuming Agamemnon task-lifecycle events will
+replace the HTTP polling loop in `_monitor_completion`. Not yet implemented._
 
 ## Implementation Status
 
 ✅ Implemented
+
 - HTTP polling for task completion — `WorkflowExecutor._monitor_completion`
   (`src/telemachy/executor.py:311`), bounded by `settings.monitor_timeout_seconds`
   and `settings.monitor_max_polls`.
@@ -43,6 +45,7 @@ _Planned (issue #92): a NATS subscriber consuming Agamemnon task-lifecycle event
   (`src/telemachy/agamemnon_client.py:49-61`).
 
 📋 Planned (tracked under #92)
+
 - NATS subscriber consuming Agamemnon task-lifecycle events.
 - Replacement of `_monitor_completion`'s polling loop with event-driven
   completion detection.
@@ -88,7 +91,9 @@ teardown: on_completion | on_failure | never
 2. **Agamemnon exclusive** — never spawn agents directly; always call ProjectAgamemnon's REST API.
 3. **Idempotent teardown** — teardown is always safe to re-run; errors are logged but do not block.
 4. **Dependency-respecting** — tasks with `blocked_by` are not submitted until their predecessors complete.
-5. **Observable** — all state transitions are logged. Task completion is detected by HTTP polling against Agamemnon's REST API in `_monitor_completion`; NATS event-driven monitoring is planned under #92 and not yet wired up.
+5. **Observable** — all state transitions are logged. Task completion is detected by HTTP
+   polling against Agamemnon's REST API in `_monitor_completion`; NATS event-driven
+   monitoring is planned under #92 and not yet wired up.
 6. **Type-safe** — all Python code uses type hints; Pydantic validates all external data.
 
 ## Repository Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,27 @@ WorkflowExecutor
     ├── AgamemnonClient  →  POST /v1/agents/{id}/start   (start agents)
     ├── AgamemnonClient  →  POST /v1/teams               (create teams)
     ├── AgamemnonClient  →  POST /v1/teams/{id}/tasks    (create tasks)
-    ├── NATS subscriber  →  monitor task completion events  (planned — not yet implemented)
     └── AgamemnonClient  →  DELETE /v1/agents/{id}       (teardown)
 ```
+
+_Planned (issue #92): a NATS subscriber consuming Agamemnon task-lifecycle events will replace the HTTP polling loop in `_monitor_completion`. Not yet implemented._
+
+## Implementation Status
+
+✅ Implemented
+- HTTP polling for task completion — `WorkflowExecutor._monitor_completion`
+  (`src/telemachy/executor.py:311`), bounded by `settings.monitor_timeout_seconds`
+  and `settings.monitor_max_polls`.
+- HTTP polling for `blocked_by` dependency unblock inside
+  `_assign_tasks` (`src/telemachy/executor.py` ~283-292).
+- TLS scheme validation on `AGAMEMNON_URL` and `NATS_URL` in
+  `AgamemnonClient.__init__` when `REQUIRE_TLS=true`
+  (`src/telemachy/agamemnon_client.py:49-61`).
+
+📋 Planned (tracked under #92)
+- NATS subscriber consuming Agamemnon task-lifecycle events.
+- Replacement of `_monitor_completion`'s polling loop with event-driven
+  completion detection.
 
 ### Key Components
 
@@ -70,8 +88,7 @@ teardown: on_completion | on_failure | never
 2. **Agamemnon exclusive** — never spawn agents directly; always call ProjectAgamemnon's REST API.
 3. **Idempotent teardown** — teardown is always safe to re-run; errors are logged but do not block.
 4. **Dependency-respecting** — tasks with `blocked_by` are not submitted until their predecessors complete.
-5. **Observable** — all state transitions are logged; completion is currently detected by HTTP
-   polling against Agamemnon (NATS event-driven completion is planned).
+5. **Observable** — all state transitions are logged. Task completion is detected by HTTP polling against Agamemnon's REST API in `_monitor_completion`; NATS event-driven monitoring is planned under #92 and not yet wired up.
 6. **Type-safe** — all Python code uses type hints; Pydantic validates all external data.
 
 ## Repository Structure
@@ -103,7 +120,7 @@ ProjectTelemachy/
 ## Development Guidelines
 
 - All Python files must have type hints on all functions and class attributes.
-- Use `async`/`await` throughout for I/O operations (HTTP, NATS).
+- Use `async`/`await` throughout for I/O operations (HTTP today; NATS once the subscriber lands under #92).
 - Use `httpx.AsyncClient` for all HTTP calls; never `requests`.
 - Pydantic v2 models for all structured data.
 - Errors from Agamemnon should raise typed exceptions, not generic ones.
@@ -155,7 +172,7 @@ just format                        # ruff format
 | --- | --- | --- |
 | `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
 | `AGAMEMNON_API_KEY` | `` | API key (if auth enabled) |
-| `NATS_URL` | `nats://localhost:4222` | NATS server URL for event monitoring |
+| `NATS_URL` | `nats://localhost:4222` | NATS server URL. Forwarded to `AgamemnonClient` and validated against `tls://` scheme when `REQUIRE_TLS=true`. **Not yet used to subscribe to events** — reserved for the planned NATS subscriber (#92). |
 | `WORKFLOWS_DIR` | `workflows` | Directory to search for workflow YAML files |
 | `HOST_ID` | `hermes` | Host identifier embedded in Agamemnon task assignments |
 | `REQUIRE_TLS` | `false` | Reject non-TLS Agamemnon connections when `true` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ just validate <WORKFLOW>
 
 Workflow definitions live in the `workflows/` directory. Reference existing workflows as
 examples for the expected schema. Workflows define steps that execute against the
-Agamemnon REST API. Inter-agent NATS messaging is part of the planned event-monitoring work (#92) and is not currently used by the engine.
+Agamemnon REST API. Inter-agent NATS messaging is part of the planned event-monitoring
+work (#92) and is not currently used by the engine.
 
 ## Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in contributing to ProjectTelemachy! This is the workflow
 execution engine for the [HomericIntelligence](https://github.com/HomericIntelligence)
 distributed agent mesh — it runs, plans, monitors, and cancels named workflow YAML files
-against Agamemnon and NATS.
+against Agamemnon's REST API. (A NATS-based event channel is planned — see issue #92 — but is not yet wired up.)
 
 For an overview of the full ecosystem, see the
 [Odysseus](https://github.com/HomericIntelligence/Odysseus) meta-repo.
@@ -66,7 +66,7 @@ just validate <WORKFLOW>
 
 Workflow definitions live in the `workflows/` directory. Reference existing workflows as
 examples for the expected schema. Workflows define steps that execute against the
-Agamemnon API and communicate over NATS subjects.
+Agamemnon REST API. Inter-agent NATS messaging is part of the planned event-monitoring work (#92) and is not currently used by the engine.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ProjectTelemachy
 
 A declarative workflow engine for [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon).
-Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, event monitoring,
+Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, completion monitoring,
 and teardown via the Agamemnon REST API.
 
 ## Overview
 
 Telemachy reads a workflow YAML file, creates agents and teams through ProjectAgamemnon, assigns tasks
-with dependency ordering, monitors task completion via NATS events, and tears down provisioned resources
+with dependency ordering, monitors task completion by polling the Agamemnon REST API (event-driven NATS monitoring is planned — see issue #92), and tears down provisioned resources
 according to your policy.
 
 No separate agent system is used. All execution is driven exclusively through ProjectAgamemnon.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ and teardown via the Agamemnon REST API.
 
 ## Overview
 
-Telemachy reads a workflow YAML file, creates agents and teams through ProjectAgamemnon, assigns tasks
-with dependency ordering, monitors task completion by polling the Agamemnon REST API (event-driven NATS monitoring is planned — see issue #92), and tears down provisioned resources
-according to your policy.
+Telemachy reads a workflow YAML file, creates agents and teams through ProjectAgamemnon,
+assigns tasks with dependency ordering, monitors task completion by polling the Agamemnon
+REST API (event-driven NATS monitoring is planned — see issue #92), and tears down
+provisioned resources according to your policy.
 
 No separate agent system is used. All execution is driven exclusively through ProjectAgamemnon.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -41,7 +41,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/70/a6c6ae98ff67b604585f4851eb0d5a595fa3a42432b08140e919462bd3f9/idna-3.17-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -193,7 +193,7 @@ packages:
   purls: []
   size: 12728445
   timestamp: 1767969922681
-- pypi: https://files.pythonhosted.org/packages/f1/70/a6c6ae98ff67b604585f4851eb0d5a595fa3a42432b08140e919462bd3f9/idna-3.17-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
   name: idna
   version: '3.17'
   sha256: 466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c

--- a/pixi.lock
+++ b/pixi.lock
@@ -41,7 +41,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/70/a6c6ae98ff67b604585f4851eb0d5a595fa3a42432b08140e919462bd3f9/idna-3.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -193,10 +193,10 @@ packages:
   purls: []
   size: 12728445
   timestamp: 1767969922681
-- pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f1/70/a6c6ae98ff67b604585f4851eb0d5a595fa3a42432b08140e919462bd3f9/idna-3.17-py3-none-any.whl
   name: idna
-  version: '3.11'
-  sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+  version: '3.17'
+  sha256: 466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c
   requires_dist:
   - ruff>=0.6.2 ; extra == 'all'
   - mypy>=1.11.2 ; extra == 'all'

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -275,7 +275,5 @@ class AgamemnonClient:
         """List all tasks for a team."""
         response = await self._request_with_retry("GET", f"/v1/teams/{team_id}/tasks")
         self._raise_for_status(response)
-        tasks: list[dict[str, object]] = _require(
-            response.json(), "tasks", context="get_tasks"
-        )
+        tasks: list[dict[str, object]] = _require(response.json(), "tasks", context="get_tasks")
         return tasks

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -41,6 +41,7 @@ def _setup_logging() -> None:
         datefmt="%Y-%m-%dT%H:%M:%S",
     )
 
+
 _SHELL_METACHARACTERS: re.Pattern[str] = re.compile(r"[;&|$`><(){}\[\]!?*~\\]")
 
 
@@ -52,9 +53,7 @@ def _validate_workflow_path(path: Path) -> None:
     """
     raw = str(path)
     if _SHELL_METACHARACTERS.search(raw):
-        raise typer.BadParameter(
-            f"Workflow path contains disallowed shell metacharacters: {raw!r}"
-        )
+        raise typer.BadParameter(f"Workflow path contains disallowed shell metacharacters: {raw!r}")
     if not path.exists():
         raise typer.BadParameter(f"Workflow file not found: {raw!r}")
     if not path.is_file():
@@ -120,8 +119,16 @@ def _print_plan(spec: WorkflowSpec) -> None:
 
 @app.command()
 def run(
-    workflow_path: Annotated[Path, typer.Argument(help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)")],
-    dry_run: Annotated[bool, typer.Option("--dry-run/--no-dry-run", help="Simulate execution without calling Agamemnon")] = False,
+    workflow_path: Annotated[
+        Path,
+        typer.Argument(
+            help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)"
+        ),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run/--no-dry-run", help="Simulate execution without calling Agamemnon"),
+    ] = False,
 ) -> None:
     """Execute a workflow YAML file."""
     _validate_workflow_path(workflow_path)
@@ -131,7 +138,9 @@ def run(
         console.print(f"[bold yellow][dry-run][/bold yellow] Simulating workflow: {spec.name}")
         _print_plan(spec)
         state = asyncio.run(run_workflow(spec, dry_run=True))
-        console.print(f"[bold yellow][dry-run][/bold yellow] Simulation complete. id={state.workflow_id}")
+        console.print(
+            f"[bold yellow][dry-run][/bold yellow] Simulation complete. id={state.workflow_id}"
+        )
         return
 
     console.print(f"[bold green]Running workflow:[/bold green] {spec.name}")
@@ -185,8 +194,7 @@ def run(
         else:
             console.print(
                 f"[bold red]Workflow {result.status}.[/bold red] "
-                f"id={result.workflow_id}"
-                + (f"  error={result.error}" if result.error else "")
+                f"id={result.workflow_id}" + (f"  error={result.error}" if result.error else "")
             )
             raise typer.Exit(1)
 
@@ -205,7 +213,12 @@ def plan(
 
 @app.command()
 def validate(
-    workflow_path: Annotated[Path, typer.Argument(help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)")],
+    workflow_path: Annotated[
+        Path,
+        typer.Argument(
+            help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)"
+        ),
+    ],
 ) -> None:
     """Validate a workflow YAML file against the Telemachy schema."""
     _validate_workflow_path(workflow_path)
@@ -259,12 +272,14 @@ def cancel(
 def schema(
     output: Path = typer.Option(  # noqa: B008
         Path("schemas/workflow-v1.json"),
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Path to write the JSON Schema file",
     ),
 ) -> None:
     """Export the workflow YAML JSON Schema for editor validation."""
     from telemachy.schema import write_workflow_schema
+
     output.parent.mkdir(parents=True, exist_ok=True)
     write_workflow_schema(output)
     typer.echo(f"Schema written to {output}")

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -63,10 +63,7 @@ class WorkflowExecutor:
         on_workflow_complete, on_workflow_failed.
         """
         if event not in self._hooks:
-            raise ValueError(
-                f"Unknown hook event {event!r}. "
-                f"Valid events: {sorted(self._hooks)}"
-            )
+            raise ValueError(f"Unknown hook event {event!r}. Valid events: {sorted(self._hooks)}")
         self._hooks[event].append(callback)
 
     async def _emit(self, event: str, **kwargs: Any) -> None:
@@ -82,7 +79,11 @@ class WorkflowExecutor:
         # Reset per-execution state so reusing the same executor for a second
         # workflow does not leak emitted-event subjects from the prior run (#203).
         self._emitted_task_events = set()
-        timeout = spec.timeout_seconds if spec.timeout_seconds is not None else settings.default_workflow_timeout
+        timeout = (
+            spec.timeout_seconds
+            if spec.timeout_seconds is not None
+            else settings.default_workflow_timeout
+        )
         try:
             return await asyncio.wait_for(self._run(spec), timeout=timeout)
         except TimeoutError as exc:
@@ -109,9 +110,7 @@ class WorkflowExecutor:
             state.created_agents = await self._provision_agents(spec.agents, state)
 
             # Create teams and submit tasks (respecting dependencies)
-            state.created_teams = await self._create_teams(
-                spec.teams, state.created_agents
-            )
+            state.created_teams = await self._create_teams(spec.teams, state.created_agents)
 
             # Monitor until all tasks reach a terminal state (skipped in dry-run)
             if not self._dry_run:
@@ -248,7 +247,7 @@ class WorkflowExecutor:
         If a dependency has failed/errored/cancelled, the dependent task is skipped
         rather than waiting forever (prevents infinite loop — see #13).
         """
-        submitted: dict[str, str] = {}   # subject → task_id
+        submitted: dict[str, str] = {}  # subject → task_id
         completed_subjects: set[str] = set()
         failed_subjects: set[str] = set()
         skipped_subjects: set[str] = set()
@@ -257,22 +256,24 @@ class WorkflowExecutor:
         while pending:
             # Skip tasks whose dependencies have failed
             newly_skipped = [
-                t for t in pending
+                t
+                for t in pending
                 if any(dep in failed_subjects or dep in skipped_subjects for dep in t.blocked_by)
             ]
             for task_spec in newly_skipped:
                 logger.warning(
                     "Skipping task '%s': a dependency failed or was skipped (%s)",
                     task_spec.subject,
-                    [dep for dep in task_spec.blocked_by if dep in failed_subjects or dep in skipped_subjects],
+                    [
+                        dep
+                        for dep in task_spec.blocked_by
+                        if dep in failed_subjects or dep in skipped_subjects
+                    ],
                 )
                 skipped_subjects.add(task_spec.subject)
                 pending.remove(task_spec)
 
-            ready = [
-                t for t in pending
-                if all(dep in completed_subjects for dep in t.blocked_by)
-            ]
+            ready = [t for t in pending if all(dep in completed_subjects for dep in t.blocked_by)]
             if not ready:
                 if not pending:
                     break
@@ -292,7 +293,9 @@ class WorkflowExecutor:
                 continue
 
             for task_spec in ready:
-                blocked_by_ids = [submitted[dep] for dep in task_spec.blocked_by if dep in submitted]
+                blocked_by_ids = [
+                    submitted[dep] for dep in task_spec.blocked_by if dep in submitted
+                ]
                 # Resolve agent name → Agamemnon agent ID before submitting (#12)
                 resolved_agent_id: str | None = None
                 if task_spec.assign_to:
@@ -301,9 +304,7 @@ class WorkflowExecutor:
                     team_id, task_spec, blocked_by_ids, assignee_agent_id=resolved_agent_id
                 )
                 submitted[task_spec.subject] = task_id
-                logger.info(
-                    "Submitted task '%s' → id=%s", task_spec.subject, task_id
-                )
+                logger.info("Submitted task '%s' → id=%s", task_spec.subject, task_id)
                 pending.remove(task_spec)
 
     # === Monitoring ===
@@ -319,7 +320,9 @@ class WorkflowExecutor:
 
         while True:
             if self._stop_event and self._stop_event.is_set():
-                logger.warning("Stop event set — aborting monitoring for workflow '%s'", state.spec.name)
+                logger.warning(
+                    "Stop event set — aborting monitoring for workflow '%s'", state.spec.name
+                )
                 state.status = "cancelled"
                 return
 
@@ -381,15 +384,12 @@ class WorkflowExecutor:
 
         policy = state.spec.teardown
 
-        should_teardown = (
-            (policy == "on_completion" and state.status == "completed")
-            or (policy == "on_failure" and state.status == "failed")
+        should_teardown = (policy == "on_completion" and state.status == "completed") or (
+            policy == "on_failure" and state.status == "failed"
         )
 
         if not should_teardown:
-            logger.info(
-                "Teardown skipped (policy=%s, status=%s)", policy, state.status
-            )
+            logger.info("Teardown skipped (policy=%s, status=%s)", policy, state.status)
             return
 
         logger.info("Running teardown for workflow '%s'...", state.spec.name)

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -55,9 +55,7 @@ class TeamSpec(BaseModel):
     def no_self_dependency(cls, tasks: list[TaskSpec]) -> list[TaskSpec]:
         for task in tasks:
             if task.subject in task.blocked_by:
-                raise ValueError(
-                    f"Task '{task.subject}' cannot depend on itself"
-                )
+                raise ValueError(f"Task '{task.subject}' cannot depend on itself")
         return tasks
 
     @model_validator(mode="after")
@@ -93,9 +91,7 @@ class TeamSpec(BaseModel):
         for task in self.tasks:
             for dep in task.blocked_by:
                 if dep not in task_subjects:
-                    raise ValueError(
-                        f"Task '{task.subject}' depends on unknown task '{dep}'"
-                    )
+                    raise ValueError(f"Task '{task.subject}' depends on unknown task '{dep}'")
 
         # Topological sort (Kahn's algorithm) to detect cycles
         in_degree: dict[str, int] = {t: 0 for t in task_subjects}
@@ -115,9 +111,7 @@ class TeamSpec(BaseModel):
                         queue.append(subject)
 
         if visited != len(task_subjects):
-            raise ValueError(
-                f"Team '{self.name}' has a dependency cycle in its tasks"
-            )
+            raise ValueError(f"Team '{self.name}' has a dependency cycle in its tasks")
 
 
 class WorkflowSpec(BaseModel):
@@ -153,9 +147,7 @@ class WorkflowSpec(BaseModel):
             # Validate agent references in team
             for agent_name in team.agents:
                 if agent_name not in agent_names:
-                    raise ValueError(
-                        f"Team '{team.name}' references unknown agent '{agent_name}'"
-                    )
+                    raise ValueError(f"Team '{team.name}' references unknown agent '{agent_name}'")
             # Validate task assign_to references
             for task in team.tasks:
                 if task.assign_to not in agent_names:
@@ -184,7 +176,7 @@ class WorkflowState(BaseModel):
     status: Literal["pending", "running", "completed", "failed", "cancelled"]
     # Use default_factory to avoid sharing a mutable default across instances.
     created_agents: dict[str, str] = Field(default_factory=dict)  # agent name → agamemnon agent id
-    created_teams: dict[str, str] = Field(default_factory=dict)   # team name → agamemnon team id
+    created_teams: dict[str, str] = Field(default_factory=dict)  # team name → agamemnon team id
     started_at: str | None = None
     completed_at: str | None = None
     error: str | None = None

--- a/src/telemachy/schema.py
+++ b/src/telemachy/schema.py
@@ -1,4 +1,5 @@
 """JSON Schema export for workflow YAML validation."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_agamemnon_client.py
+++ b/tests/test_agamemnon_client.py
@@ -33,6 +33,7 @@ async def _enter_client(url: str = "http://localhost:8080", **kwargs: object) ->
     client = AgamemnonClient(url=url, **kwargs)  # type: ignore[arg-type]
     # Manually install a real-ish AsyncClient so _http property works
     import httpx
+
     client._client = httpx.AsyncClient(base_url=url)
     return client
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,9 +82,7 @@ def test_validate_valid_yaml(valid_workflow_file: Path) -> None:
     """validate command exits 0 and prints 'valid' for a correct YAML."""
     result = runner.invoke(app, ["validate", str(valid_workflow_file)])
     assert result.exit_code == 0, f"Unexpected exit code. Output:\n{result.output}"
-    assert "valid" in result.output.lower(), (
-        f"Expected 'valid' in output but got:\n{result.output}"
-    )
+    assert "valid" in result.output.lower(), f"Expected 'valid' in output but got:\n{result.output}"
 
 
 # ---------------------------------------------------------------------------
@@ -178,18 +176,14 @@ def test_run_dry_run(valid_workflow_file: Path) -> None:
 
     with patch("telemachy.cli.run_workflow", new_callable=AsyncMock) as mock_run:
         mock_run.return_value = mock_state
-        result = runner.invoke(
-            app, ["run", str(valid_workflow_file), "--dry-run"]
-        )
+        result = runner.invoke(app, ["run", str(valid_workflow_file), "--dry-run"])
 
     assert result.exit_code == 0, (
-        f"Expected exit code 0 for --dry-run, got {result.exit_code}. "
-        f"Output:\n{result.output}"
+        f"Expected exit code 0 for --dry-run, got {result.exit_code}. Output:\n{result.output}"
     )
     # run_workflow should have been called once with dry_run=True
     mock_run.assert_called_once()
     _args, kwargs = mock_run.call_args
     assert kwargs.get("dry_run") is True or (len(_args) > 1 and _args[1] is True), (
-        f"Expected run_workflow to be called with dry_run=True, "
-        f"call_args={mock_run.call_args}"
+        f"Expected run_workflow to be called with dry_run=True, call_args={mock_run.call_args}"
     )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -14,15 +14,14 @@ from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_spec(
     agents: list[dict] | None = None,
     tasks: list[dict] | None = None,
     teardown: str = "on_completion",
 ) -> WorkflowSpec:
     agents = agents or [{"name": "worker", "runtime": "local"}]
-    tasks = tasks or [
-        {"subject": "Task 1", "description": "Do work", "assign_to": "worker"}
-    ]
+    tasks = tasks or [{"subject": "Task 1", "description": "Do work", "assign_to": "worker"}]
     return WorkflowSpec.model_validate(
         {
             "apiVersion": "telemachy/v1",
@@ -50,15 +49,14 @@ def _make_mock_client() -> MagicMock:
     client.create_team = AsyncMock(return_value="team-id-001")
     client.create_task = AsyncMock(return_value="task-id-001")
     client.update_task = AsyncMock()
-    client.get_tasks = AsyncMock(
-        return_value=[{"subject": "Task 1", "status": "completed"}]
-    )
+    client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "completed"}])
     return client
 
 
 # ---------------------------------------------------------------------------
 # Tests: provisioning
 # ---------------------------------------------------------------------------
+
 
 class TestProvisioning:
     @pytest.mark.asyncio
@@ -120,6 +118,7 @@ class TestProvisioning:
 # Tests: team and task creation
 # ---------------------------------------------------------------------------
 
+
 class TestTaskCreation:
     @pytest.mark.asyncio
     async def test_create_team_called(self) -> None:
@@ -166,7 +165,10 @@ class TestTaskCreation:
         get_tasks_responses = [
             [{"subject": "Step 1", "status": "pending"}],
             [{"subject": "Step 1", "status": "completed"}],
-            [{"subject": "Step 1", "status": "completed"}, {"subject": "Step 2", "status": "completed"}],
+            [
+                {"subject": "Step 1", "status": "completed"},
+                {"subject": "Step 2", "status": "completed"},
+            ],
         ]
         call_count = {"n": 0}
 
@@ -200,6 +202,7 @@ class TestTaskCreation:
 # ---------------------------------------------------------------------------
 # Tests: teardown
 # ---------------------------------------------------------------------------
+
 
 class TestTeardown:
     @pytest.mark.asyncio
@@ -248,9 +251,7 @@ class TestTeardown:
     @pytest.mark.asyncio
     async def test_failed_state_when_task_fails(self) -> None:
         client = _make_mock_client()
-        client.get_tasks = AsyncMock(
-            return_value=[{"subject": "Task 1", "status": "failed"}]
-        )
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "failed"}])
         spec = _make_spec(teardown="never")
 
         executor = WorkflowExecutor(client, poll_interval=0.01)
@@ -263,6 +264,7 @@ class TestTeardown:
 # ---------------------------------------------------------------------------
 # Tests: error paths
 # ---------------------------------------------------------------------------
+
 
 class TestErrorPaths:
     @pytest.mark.asyncio
@@ -308,10 +310,7 @@ class TestErrorPaths:
         assert state.completed_at is not None
 
         # Task B must never have been submitted
-        submitted_subjects = [
-            call.args[1].subject
-            for call in client.create_task.call_args_list
-        ]
+        submitted_subjects = [call.args[1].subject for call in client.create_task.call_args_list]
         assert "Task B" not in submitted_subjects
         assert "Task A" in submitted_subjects
 
@@ -394,9 +393,11 @@ class TestErrorPaths:
         deleted_ids = [call.args[0] for call in client.delete_agent.call_args_list]
         assert "agent-id-first" in deleted_ids
 
+
 # ---------------------------------------------------------------------------
 # Tests: hooks (#144)
 # ---------------------------------------------------------------------------
+
 
 class TestHooks:
     def test_add_hook_rejects_unknown_event(self) -> None:
@@ -443,6 +444,7 @@ class TestHooks:
 # Tests: timeout behaviour (#142)
 # ---------------------------------------------------------------------------
 
+
 class TestWorkflowTimeout:
     @pytest.mark.asyncio
     async def test_execute_raises_workflow_timeout_error_on_wait_for_timeout(self) -> None:
@@ -468,6 +470,7 @@ class TestWorkflowTimeout:
 # ---------------------------------------------------------------------------
 # Tests: stop-event graceful cancellation (#143)
 # ---------------------------------------------------------------------------
+
 
 class TestStopEvent:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Eliminates the false mental model that ProjectTelemachy monitors task completion via NATS events. Across all contributor-facing documentation, this clarifies that:

- Task completion is detected by **HTTP polling** in `WorkflowExecutor._monitor_completion`
- NATS event-driven monitoring is **planned** (umbrella issue #92), not implemented
- `NATS_URL` is currently used only for TLS scheme validation, not for event subscription

## Changes

- **CLAUDE.md**: Removed NATS subscriber from architecture diagram, added Implementation Status section documenting what is implemented vs planned
- **README.md**: Changed "event monitoring" to "completion monitoring" and clarified HTTP polling with NATS as planned
- **CONTRIBUTING.md**: Updated two sections to correctly describe HTTP polling and explicitly note NATS as planned work

Closes #171