### PR TITLE
fix(security): default REQUIRE_TLS to true (#158)

### DIFF
--- a/.claude-followup-158.json
+++ b/.claude-followup-158.json
@@ -1,0 +1,13 @@
+{
+  "follow_ups": [],
+  "rejected": [
+    {
+      "title": "Suppress warning during test collection when .env has REQUIRE_TLS=false",
+      "reason": "Expected behavior, not a defect: warning is intentional and informational. Tests using Settings(_env_file=None) are already isolated. Cosmetic noise from developer .env overrides is acceptable per design."
+    },
+    {
+      "title": "Add test isolation for module-level settings imports in cli.py and executor.py",
+      "reason": "Out of scope: test coverage for code outside what was just touched. New tests in test_config.py already cover the Settings behavior; side effects on legacy imports are expected and documented."
+    }
+  ]
+}

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,10 @@ WORKFLOWS_DIR=workflows
 # Identifier for this host, embedded in Agamemnon task assignments
 HOST_ID=hermes
 
-# Set to true to reject non-TLS Agamemnon connections
-REQUIRE_TLS=false
+# TLS enforcement: defaults to true. Telemachy will refuse to connect
+# to Agamemnon over plain http:// or plain nats://. For LOCAL DEV ONLY,
+# uncomment the line below to allow cleartext (a WARNING is logged):
+# REQUIRE_TLS=false
 
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
-- `REQUIRE_TLS` env var now defaults to `true` (was `false`). Closes #158; part of #92. Telemachy will refuse to construct `AgamemnonClient` against plain `http://` Agamemnon URLs or plain `nats://` NATS URLs unless the operator explicitly sets `REQUIRE_TLS=false`.
-  - Before: missing `REQUIRE_TLS` → silently allowed cleartext HTTP, transmitting the Bearer API key in the clear.
-  - After: missing `REQUIRE_TLS` → `AgamemnonClient.__init__` raises `AgamemnonError` when `AGAMEMNON_URL` starts with `http://` (or `NATS_URL` starts with `nats://`). Set `REQUIRE_TLS=false` in your `.env` to opt back in for local dev — a `WARNING` is emitted at `Settings` construction time.
+- `REQUIRE_TLS` env var now defaults to `true` (was `false`). Closes #158; part of #92.
+  Telemachy will refuse to construct `AgamemnonClient` against plain `http://` Agamemnon
+  URLs or plain `nats://` NATS URLs unless the operator explicitly sets
+  `REQUIRE_TLS=false`.
+  - Before: missing `REQUIRE_TLS` → silently allowed cleartext HTTP, transmitting the
+    Bearer API key in the clear.
+  - After: missing `REQUIRE_TLS` → `AgamemnonClient.__init__` raises `AgamemnonError`
+    when `AGAMEMNON_URL` starts with `http://` (or `NATS_URL` starts with `nats://`).
+    Set `REQUIRE_TLS=false` in your `.env` to opt back in for local dev — a `WARNING`
+    is emitted at `Settings` construction time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pydantic v2 models for workflow schema validation
 - NATS URL configuration (subscriber implementation pending)
 - Docker and local runtime support for agent provisioning
+
+### Changed (breaking)
+
+- `REQUIRE_TLS` env var now defaults to `true` (was `false`). Closes #158; part of #92. Telemachy will refuse to construct `AgamemnonClient` against plain `http://` Agamemnon URLs or plain `nats://` NATS URLs unless the operator explicitly sets `REQUIRE_TLS=false`.
+  - Before: missing `REQUIRE_TLS` → silently allowed cleartext HTTP, transmitting the Bearer API key in the clear.
+  - After: missing `REQUIRE_TLS` → `AgamemnonClient.__init__` raises `AgamemnonError` when `AGAMEMNON_URL` starts with `http://` (or `NATS_URL` starts with `nats://`). Set `REQUIRE_TLS=false` in your `.env` to opt back in for local dev — a `WARNING` is emitted at `Settings` construction time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ just format                        # ruff format
 | `NATS_URL` | `nats://localhost:4222` | NATS server URL for event monitoring |
 | `WORKFLOWS_DIR` | `workflows` | Directory to search for workflow YAML files |
 | `HOST_ID` | `hermes` | Host identifier embedded in Agamemnon task assignments |
-| `REQUIRE_TLS` | `false` | Reject non-TLS Agamemnon connections when `true` |
+| `REQUIRE_TLS` | `true` | Reject non-TLS Agamemnon connections. Set to `false` to allow cleartext for local dev (logs a WARNING). |
 | `LOG_LEVEL` | `INFO` | Python logging level (DEBUG, INFO, WARNING, ERROR) |
 | `MONITOR_TIMEOUT_SECONDS` | `3600` | Seconds before workflow monitor times out |
 | `MONITOR_MAX_POLLS` | `7200` | Maximum polling attempts for workflow monitor |

--- a/docs/migrations/0.2.md
+++ b/docs/migrations/0.2.md
@@ -4,12 +4,16 @@
 
 ### What Changed
 
-The `REQUIRE_TLS` environment variable now **defaults to `true`** instead of `false`. This change improves security by making TLS (encryption) the default mode for all Agamemnon connections.
+The `REQUIRE_TLS` environment variable now **defaults to `true`** instead of `false`.
+This change improves security by making TLS (encryption) the default mode for all
+Agamemnon connections.
 
 ### Who Is Affected
 
-- **Local developers** running Telemachy without explicit `REQUIRE_TLS=false`: your workflow runs will now fail unless you opt into cleartext mode.
-- **Production / CI environments**: no change required if you are already using TLS (the secure configuration).
+- **Local developers** running Telemachy without explicit `REQUIRE_TLS=false`: your
+  workflow runs will now fail unless you opt into cleartext mode.
+- **Production / CI environments**: no change required if you are already using TLS
+  (the secure configuration).
 
 ### Before: 0.1.x
 
@@ -37,21 +41,31 @@ telemachy run workflows/example.yaml  # works; WARNING emitted
 ### How to Migrate
 
 **Option 1: Use TLS (recommended)**
+
 - Point your `AGAMEMNON_URL` to a TLS endpoint (e.g., `https://...`).
 - Remove `REQUIRE_TLS=false` from your `.env`.
 - No code changes needed.
 
 **Option 2: Allow cleartext for local development only**
+
 - In your `.env`, add or uncomment:
-  ```
-  REQUIRE_TLS=false
-  ```
+
+```
+REQUIRE_TLS=false
+```
+
 - A `WARNING` will be logged at startup:
-  ```
-  WARNING telemachy.config: REQUIRE_TLS=false set explicitly ...
-  ```
+
+```
+WARNING telemachy.config: REQUIRE_TLS=false set explicitly ...
+```
+
 - Treat this as a temporary local-dev-only setting — never commit it to a deployment.
 
 ### Rationale
 
-Before 0.2.0, developers who omitted `REQUIRE_TLS` would silently connect over plaintext, transmitting API keys in cleartext HTTP headers. This is insecure. By flipping the default to `true`, we ensure that the secure configuration (TLS) is the path of least resistance. See [issue #158](https://github.com/telemachy/telemachy/issues/158) and [issue #92](https://github.com/telemachy/telemachy/issues/92).
+Before 0.2.0, developers who omitted `REQUIRE_TLS` would silently connect over
+plaintext, transmitting API keys in cleartext HTTP headers. This is insecure. By
+flipping the default to `true`, we ensure that the secure configuration (TLS) is the
+path of least resistance. See [issue #158](https://github.com/telemachy/telemachy/issues/158)
+and [issue #92](https://github.com/telemachy/telemachy/issues/92).

--- a/docs/migrations/0.2.md
+++ b/docs/migrations/0.2.md
@@ -1,0 +1,57 @@
+# Migration Guide: 0.1.x → 0.2.0
+
+## Breaking Change: `REQUIRE_TLS` Now Defaults to `true`
+
+### What Changed
+
+The `REQUIRE_TLS` environment variable now **defaults to `true`** instead of `false`. This change improves security by making TLS (encryption) the default mode for all Agamemnon connections.
+
+### Who Is Affected
+
+- **Local developers** running Telemachy without explicit `REQUIRE_TLS=false`: your workflow runs will now fail unless you opt into cleartext mode.
+- **Production / CI environments**: no change required if you are already using TLS (the secure configuration).
+
+### Before: 0.1.x
+
+```bash
+# No REQUIRE_TLS set → silently allows plaintext HTTP
+# ❌ API key transmitted in cleartext
+export AGAMEMNON_URL=http://localhost:8080
+telemachy run workflows/example.yaml  # works but insecure
+```
+
+### After: 0.2.0
+
+```bash
+# No REQUIRE_TLS set → raises AgamemnonError
+# Telemachy refuses to connect over plaintext
+export AGAMEMNON_URL=http://localhost:8080
+telemachy run workflows/example.yaml  # ❌ AgamemnonError: TLS required
+
+# ✅ Explicit opt-in for local dev (logs WARNING)
+export REQUIRE_TLS=false
+export AGAMEMNON_URL=http://localhost:8080
+telemachy run workflows/example.yaml  # works; WARNING emitted
+```
+
+### How to Migrate
+
+**Option 1: Use TLS (recommended)**
+- Point your `AGAMEMNON_URL` to a TLS endpoint (e.g., `https://...`).
+- Remove `REQUIRE_TLS=false` from your `.env`.
+- No code changes needed.
+
+**Option 2: Allow cleartext for local development only**
+- In your `.env`, add or uncomment:
+  ```
+  REQUIRE_TLS=false
+  ```
+- A `WARNING` will be logged at startup:
+  ```
+  WARNING telemachy.config: REQUIRE_TLS=false set explicitly ...
+  ```
+- Treat this as a temporary local-dev-only setting — never commit it to a deployment.
+
+### Rationale
+
+Before 0.2.0, developers who omitted `REQUIRE_TLS` would silently connect over plaintext, transmitting API keys in cleartext HTTP headers. This is insecure. By flipping the default to `true`, we ensure that the secure configuration (TLS) is the path of least resistance. See [issue #158](https://github.com/telemachy/telemachy/issues/158) and [issue #92](https://github.com/telemachy/telemachy/issues/92).

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "project-telemachy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Declarative workflow engine for ProjectAgamemnon multi-agent workflows"
 channels = ["conda-forge"]
 platforms = ["linux-64"]

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -275,7 +275,5 @@ class AgamemnonClient:
         """List all tasks for a team."""
         response = await self._request_with_retry("GET", f"/v1/teams/{team_id}/tasks")
         self._raise_for_status(response)
-        tasks: list[dict[str, object]] = _require(
-            response.json(), "tasks", context="get_tasks"
-        )
+        tasks: list[dict[str, object]] = _require(response.json(), "tasks", context="get_tasks")
         return tasks

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -41,6 +41,7 @@ def _setup_logging() -> None:
         datefmt="%Y-%m-%dT%H:%M:%S",
     )
 
+
 _SHELL_METACHARACTERS: re.Pattern[str] = re.compile(r"[;&|$`><(){}\[\]!?*~\\]")
 
 
@@ -52,9 +53,7 @@ def _validate_workflow_path(path: Path) -> None:
     """
     raw = str(path)
     if _SHELL_METACHARACTERS.search(raw):
-        raise typer.BadParameter(
-            f"Workflow path contains disallowed shell metacharacters: {raw!r}"
-        )
+        raise typer.BadParameter(f"Workflow path contains disallowed shell metacharacters: {raw!r}")
     if not path.exists():
         raise typer.BadParameter(f"Workflow file not found: {raw!r}")
     if not path.is_file():
@@ -120,8 +119,16 @@ def _print_plan(spec: WorkflowSpec) -> None:
 
 @app.command()
 def run(
-    workflow_path: Annotated[Path, typer.Argument(help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)")],
-    dry_run: Annotated[bool, typer.Option("--dry-run/--no-dry-run", help="Simulate execution without calling Agamemnon")] = False,
+    workflow_path: Annotated[
+        Path,
+        typer.Argument(
+            help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)"
+        ),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run/--no-dry-run", help="Simulate execution without calling Agamemnon"),
+    ] = False,
 ) -> None:
     """Execute a workflow YAML file."""
     _validate_workflow_path(workflow_path)
@@ -131,7 +138,9 @@ def run(
         console.print(f"[bold yellow][dry-run][/bold yellow] Simulating workflow: {spec.name}")
         _print_plan(spec)
         state = asyncio.run(run_workflow(spec, dry_run=True))
-        console.print(f"[bold yellow][dry-run][/bold yellow] Simulation complete. id={state.workflow_id}")
+        console.print(
+            f"[bold yellow][dry-run][/bold yellow] Simulation complete. id={state.workflow_id}"
+        )
         return
 
     console.print(f"[bold green]Running workflow:[/bold green] {spec.name}")
@@ -185,8 +194,7 @@ def run(
         else:
             console.print(
                 f"[bold red]Workflow {result.status}.[/bold red] "
-                f"id={result.workflow_id}"
-                + (f"  error={result.error}" if result.error else "")
+                f"id={result.workflow_id}" + (f"  error={result.error}" if result.error else "")
             )
             raise typer.Exit(1)
 
@@ -205,7 +213,12 @@ def plan(
 
 @app.command()
 def validate(
-    workflow_path: Annotated[Path, typer.Argument(help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)")],
+    workflow_path: Annotated[
+        Path,
+        typer.Argument(
+            help=f"Path to workflow YAML file (default search dir: {settings.workflows_dir}, override with WORKFLOWS_DIR env var)"
+        ),
+    ],
 ) -> None:
     """Validate a workflow YAML file against the Telemachy schema."""
     _validate_workflow_path(workflow_path)
@@ -259,12 +272,14 @@ def cancel(
 def schema(
     output: Path = typer.Option(  # noqa: B008
         Path("schemas/workflow-v1.json"),
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Path to write the JSON Schema file",
     ),
 ) -> None:
     """Export the workflow YAML JSON Schema for editor validation."""
     from telemachy.schema import write_workflow_schema
+
     output.parent.mkdir(parents=True, exist_ok=True)
     write_workflow_schema(output)
     typer.echo(f"Schema written to {output}")

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TypedDict
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class AgamemnonClientKwargs(TypedDict):
@@ -32,11 +36,21 @@ class Settings(BaseSettings):
     nats_url: str = "nats://localhost:4222"
     workflows_dir: Path = Path("workflows")
     host_id: str = "hermes"
-    require_tls: bool = False
+    require_tls: bool = True
     monitor_timeout_seconds: float = 3600.0
     monitor_max_polls: int = 7200
     log_level: str = "INFO"
     default_workflow_timeout: float = 7200.0
+
+    @model_validator(mode="after")
+    def _warn_if_tls_disabled(self) -> Settings:
+        if not self.require_tls:
+            logger.warning(
+                "REQUIRE_TLS=false set explicitly — Agamemnon traffic "
+                "(including API key in Authorization header) will be "
+                "transmitted in cleartext. Use only for local development."
+            )
+        return self
 
     def client_kwargs(self) -> AgamemnonClientKwargs:
         """Return keyword arguments for constructing an AgamemnonClient.

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -63,10 +63,7 @@ class WorkflowExecutor:
         on_workflow_complete, on_workflow_failed.
         """
         if event not in self._hooks:
-            raise ValueError(
-                f"Unknown hook event {event!r}. "
-                f"Valid events: {sorted(self._hooks)}"
-            )
+            raise ValueError(f"Unknown hook event {event!r}. Valid events: {sorted(self._hooks)}")
         self._hooks[event].append(callback)
 
     async def _emit(self, event: str, **kwargs: Any) -> None:
@@ -82,7 +79,11 @@ class WorkflowExecutor:
         # Reset per-execution state so reusing the same executor for a second
         # workflow does not leak emitted-event subjects from the prior run (#203).
         self._emitted_task_events = set()
-        timeout = spec.timeout_seconds if spec.timeout_seconds is not None else settings.default_workflow_timeout
+        timeout = (
+            spec.timeout_seconds
+            if spec.timeout_seconds is not None
+            else settings.default_workflow_timeout
+        )
         try:
             return await asyncio.wait_for(self._run(spec), timeout=timeout)
         except TimeoutError as exc:
@@ -109,9 +110,7 @@ class WorkflowExecutor:
             state.created_agents = await self._provision_agents(spec.agents, state)
 
             # Create teams and submit tasks (respecting dependencies)
-            state.created_teams = await self._create_teams(
-                spec.teams, state.created_agents
-            )
+            state.created_teams = await self._create_teams(spec.teams, state.created_agents)
 
             # Monitor until all tasks reach a terminal state (skipped in dry-run)
             if not self._dry_run:
@@ -248,7 +247,7 @@ class WorkflowExecutor:
         If a dependency has failed/errored/cancelled, the dependent task is skipped
         rather than waiting forever (prevents infinite loop — see #13).
         """
-        submitted: dict[str, str] = {}   # subject → task_id
+        submitted: dict[str, str] = {}  # subject → task_id
         completed_subjects: set[str] = set()
         failed_subjects: set[str] = set()
         skipped_subjects: set[str] = set()
@@ -257,22 +256,24 @@ class WorkflowExecutor:
         while pending:
             # Skip tasks whose dependencies have failed
             newly_skipped = [
-                t for t in pending
+                t
+                for t in pending
                 if any(dep in failed_subjects or dep in skipped_subjects for dep in t.blocked_by)
             ]
             for task_spec in newly_skipped:
                 logger.warning(
                     "Skipping task '%s': a dependency failed or was skipped (%s)",
                     task_spec.subject,
-                    [dep for dep in task_spec.blocked_by if dep in failed_subjects or dep in skipped_subjects],
+                    [
+                        dep
+                        for dep in task_spec.blocked_by
+                        if dep in failed_subjects or dep in skipped_subjects
+                    ],
                 )
                 skipped_subjects.add(task_spec.subject)
                 pending.remove(task_spec)
 
-            ready = [
-                t for t in pending
-                if all(dep in completed_subjects for dep in t.blocked_by)
-            ]
+            ready = [t for t in pending if all(dep in completed_subjects for dep in t.blocked_by)]
             if not ready:
                 if not pending:
                     break
@@ -292,7 +293,9 @@ class WorkflowExecutor:
                 continue
 
             for task_spec in ready:
-                blocked_by_ids = [submitted[dep] for dep in task_spec.blocked_by if dep in submitted]
+                blocked_by_ids = [
+                    submitted[dep] for dep in task_spec.blocked_by if dep in submitted
+                ]
                 # Resolve agent name → Agamemnon agent ID before submitting (#12)
                 resolved_agent_id: str | None = None
                 if task_spec.assign_to:
@@ -301,9 +304,7 @@ class WorkflowExecutor:
                     team_id, task_spec, blocked_by_ids, assignee_agent_id=resolved_agent_id
                 )
                 submitted[task_spec.subject] = task_id
-                logger.info(
-                    "Submitted task '%s' → id=%s", task_spec.subject, task_id
-                )
+                logger.info("Submitted task '%s' → id=%s", task_spec.subject, task_id)
                 pending.remove(task_spec)
 
     # === Monitoring ===
@@ -319,7 +320,9 @@ class WorkflowExecutor:
 
         while True:
             if self._stop_event and self._stop_event.is_set():
-                logger.warning("Stop event set — aborting monitoring for workflow '%s'", state.spec.name)
+                logger.warning(
+                    "Stop event set — aborting monitoring for workflow '%s'", state.spec.name
+                )
                 state.status = "cancelled"
                 return
 
@@ -381,15 +384,12 @@ class WorkflowExecutor:
 
         policy = state.spec.teardown
 
-        should_teardown = (
-            (policy == "on_completion" and state.status == "completed")
-            or (policy == "on_failure" and state.status == "failed")
+        should_teardown = (policy == "on_completion" and state.status == "completed") or (
+            policy == "on_failure" and state.status == "failed"
         )
 
         if not should_teardown:
-            logger.info(
-                "Teardown skipped (policy=%s, status=%s)", policy, state.status
-            )
+            logger.info("Teardown skipped (policy=%s, status=%s)", policy, state.status)
             return
 
         logger.info("Running teardown for workflow '%s'...", state.spec.name)

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -55,9 +55,7 @@ class TeamSpec(BaseModel):
     def no_self_dependency(cls, tasks: list[TaskSpec]) -> list[TaskSpec]:
         for task in tasks:
             if task.subject in task.blocked_by:
-                raise ValueError(
-                    f"Task '{task.subject}' cannot depend on itself"
-                )
+                raise ValueError(f"Task '{task.subject}' cannot depend on itself")
         return tasks
 
     @model_validator(mode="after")
@@ -93,9 +91,7 @@ class TeamSpec(BaseModel):
         for task in self.tasks:
             for dep in task.blocked_by:
                 if dep not in task_subjects:
-                    raise ValueError(
-                        f"Task '{task.subject}' depends on unknown task '{dep}'"
-                    )
+                    raise ValueError(f"Task '{task.subject}' depends on unknown task '{dep}'")
 
         # Topological sort (Kahn's algorithm) to detect cycles
         in_degree: dict[str, int] = {t: 0 for t in task_subjects}
@@ -115,9 +111,7 @@ class TeamSpec(BaseModel):
                         queue.append(subject)
 
         if visited != len(task_subjects):
-            raise ValueError(
-                f"Team '{self.name}' has a dependency cycle in its tasks"
-            )
+            raise ValueError(f"Team '{self.name}' has a dependency cycle in its tasks")
 
 
 class WorkflowSpec(BaseModel):
@@ -153,9 +147,7 @@ class WorkflowSpec(BaseModel):
             # Validate agent references in team
             for agent_name in team.agents:
                 if agent_name not in agent_names:
-                    raise ValueError(
-                        f"Team '{team.name}' references unknown agent '{agent_name}'"
-                    )
+                    raise ValueError(f"Team '{team.name}' references unknown agent '{agent_name}'")
             # Validate task assign_to references
             for task in team.tasks:
                 if task.assign_to not in agent_names:
@@ -184,7 +176,7 @@ class WorkflowState(BaseModel):
     status: Literal["pending", "running", "completed", "failed", "cancelled"]
     # Use default_factory to avoid sharing a mutable default across instances.
     created_agents: dict[str, str] = Field(default_factory=dict)  # agent name → agamemnon agent id
-    created_teams: dict[str, str] = Field(default_factory=dict)   # team name → agamemnon team id
+    created_teams: dict[str, str] = Field(default_factory=dict)  # team name → agamemnon team id
     started_at: str | None = None
     completed_at: str | None = None
     error: str | None = None

--- a/src/telemachy/schema.py
+++ b/src/telemachy/schema.py
@@ -1,4 +1,5 @@
 """JSON Schema export for workflow YAML validation."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_agamemnon_client.py
+++ b/tests/test_agamemnon_client.py
@@ -33,6 +33,7 @@ async def _enter_client(url: str = "http://localhost:8080", **kwargs: object) ->
     client = AgamemnonClient(url=url, **kwargs)  # type: ignore[arg-type]
     # Manually install a real-ish AsyncClient so _http property works
     import httpx
+
     client._client = httpx.AsyncClient(base_url=url)
     return client
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,9 +82,7 @@ def test_validate_valid_yaml(valid_workflow_file: Path) -> None:
     """validate command exits 0 and prints 'valid' for a correct YAML."""
     result = runner.invoke(app, ["validate", str(valid_workflow_file)])
     assert result.exit_code == 0, f"Unexpected exit code. Output:\n{result.output}"
-    assert "valid" in result.output.lower(), (
-        f"Expected 'valid' in output but got:\n{result.output}"
-    )
+    assert "valid" in result.output.lower(), f"Expected 'valid' in output but got:\n{result.output}"
 
 
 # ---------------------------------------------------------------------------
@@ -178,18 +176,14 @@ def test_run_dry_run(valid_workflow_file: Path) -> None:
 
     with patch("telemachy.cli.run_workflow", new_callable=AsyncMock) as mock_run:
         mock_run.return_value = mock_state
-        result = runner.invoke(
-            app, ["run", str(valid_workflow_file), "--dry-run"]
-        )
+        result = runner.invoke(app, ["run", str(valid_workflow_file), "--dry-run"])
 
     assert result.exit_code == 0, (
-        f"Expected exit code 0 for --dry-run, got {result.exit_code}. "
-        f"Output:\n{result.output}"
+        f"Expected exit code 0 for --dry-run, got {result.exit_code}. Output:\n{result.output}"
     )
     # run_workflow should have been called once with dry_run=True
     mock_run.assert_called_once()
     _args, kwargs = mock_run.call_args
     assert kwargs.get("dry_run") is True or (len(_args) > 1 and _args[1] is True), (
-        f"Expected run_workflow to be called with dry_run=True, "
-        f"call_args={mock_run.call_args}"
+        f"Expected run_workflow to be called with dry_run=True, call_args={mock_run.call_args}"
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+"""Tests for configuration settings."""
+
+import logging
+
+import pytest
+
+from telemachy.config import Settings
+
+
+def test_require_tls_default_is_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that REQUIRE_TLS defaults to True."""
+    monkeypatch.delenv("REQUIRE_TLS", raising=False)
+    settings = Settings(_env_file=None)
+    assert settings.require_tls is True
+
+
+def test_require_tls_false_emits_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify that setting REQUIRE_TLS=false emits a WARNING."""
+    monkeypatch.setenv("REQUIRE_TLS", "false")
+    with caplog.at_level(logging.WARNING, logger="telemachy.config"):
+        Settings(_env_file=None)
+    assert any("cleartext" in record.message for record in caplog.records)
+
+
+def test_require_tls_true_emits_no_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify that default REQUIRE_TLS=true emits no warning."""
+    monkeypatch.delenv("REQUIRE_TLS", raising=False)
+    with caplog.at_level(logging.WARNING, logger="telemachy.config"):
+        Settings(_env_file=None)
+    assert not any("cleartext" in record.message for record in caplog.records)
+
+
+def test_client_kwargs_propagates_require_tls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that client_kwargs() propagates require_tls correctly."""
+    # Test default (True)
+    monkeypatch.delenv("REQUIRE_TLS", raising=False)
+    settings = Settings(_env_file=None)
+    assert settings.client_kwargs()["require_tls"] is True
+
+    # Test override (False)
+    monkeypatch.setenv("REQUIRE_TLS", "false")
+    settings = Settings(_env_file=None)
+    assert settings.client_kwargs()["require_tls"] is False

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -14,15 +14,14 @@ from telemachy.models import AgentSpec, TaskSpec, WorkflowSpec
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_spec(
     agents: list[dict] | None = None,
     tasks: list[dict] | None = None,
     teardown: str = "on_completion",
 ) -> WorkflowSpec:
     agents = agents or [{"name": "worker", "runtime": "local"}]
-    tasks = tasks or [
-        {"subject": "Task 1", "description": "Do work", "assign_to": "worker"}
-    ]
+    tasks = tasks or [{"subject": "Task 1", "description": "Do work", "assign_to": "worker"}]
     return WorkflowSpec.model_validate(
         {
             "apiVersion": "telemachy/v1",
@@ -50,15 +49,14 @@ def _make_mock_client() -> MagicMock:
     client.create_team = AsyncMock(return_value="team-id-001")
     client.create_task = AsyncMock(return_value="task-id-001")
     client.update_task = AsyncMock()
-    client.get_tasks = AsyncMock(
-        return_value=[{"subject": "Task 1", "status": "completed"}]
-    )
+    client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "completed"}])
     return client
 
 
 # ---------------------------------------------------------------------------
 # Tests: provisioning
 # ---------------------------------------------------------------------------
+
 
 class TestProvisioning:
     @pytest.mark.asyncio
@@ -120,6 +118,7 @@ class TestProvisioning:
 # Tests: team and task creation
 # ---------------------------------------------------------------------------
 
+
 class TestTaskCreation:
     @pytest.mark.asyncio
     async def test_create_team_called(self) -> None:
@@ -166,7 +165,10 @@ class TestTaskCreation:
         get_tasks_responses = [
             [{"subject": "Step 1", "status": "pending"}],
             [{"subject": "Step 1", "status": "completed"}],
-            [{"subject": "Step 1", "status": "completed"}, {"subject": "Step 2", "status": "completed"}],
+            [
+                {"subject": "Step 1", "status": "completed"},
+                {"subject": "Step 2", "status": "completed"},
+            ],
         ]
         call_count = {"n": 0}
 
@@ -200,6 +202,7 @@ class TestTaskCreation:
 # ---------------------------------------------------------------------------
 # Tests: teardown
 # ---------------------------------------------------------------------------
+
 
 class TestTeardown:
     @pytest.mark.asyncio
@@ -248,9 +251,7 @@ class TestTeardown:
     @pytest.mark.asyncio
     async def test_failed_state_when_task_fails(self) -> None:
         client = _make_mock_client()
-        client.get_tasks = AsyncMock(
-            return_value=[{"subject": "Task 1", "status": "failed"}]
-        )
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "failed"}])
         spec = _make_spec(teardown="never")
 
         executor = WorkflowExecutor(client, poll_interval=0.01)
@@ -263,6 +264,7 @@ class TestTeardown:
 # ---------------------------------------------------------------------------
 # Tests: error paths
 # ---------------------------------------------------------------------------
+
 
 class TestErrorPaths:
     @pytest.mark.asyncio
@@ -308,10 +310,7 @@ class TestErrorPaths:
         assert state.completed_at is not None
 
         # Task B must never have been submitted
-        submitted_subjects = [
-            call.args[1].subject
-            for call in client.create_task.call_args_list
-        ]
+        submitted_subjects = [call.args[1].subject for call in client.create_task.call_args_list]
         assert "Task B" not in submitted_subjects
         assert "Task A" in submitted_subjects
 
@@ -394,9 +393,11 @@ class TestErrorPaths:
         deleted_ids = [call.args[0] for call in client.delete_agent.call_args_list]
         assert "agent-id-first" in deleted_ids
 
+
 # ---------------------------------------------------------------------------
 # Tests: hooks (#144)
 # ---------------------------------------------------------------------------
+
 
 class TestHooks:
     def test_add_hook_rejects_unknown_event(self) -> None:
@@ -443,6 +444,7 @@ class TestHooks:
 # Tests: timeout behaviour (#142)
 # ---------------------------------------------------------------------------
 
+
 class TestWorkflowTimeout:
     @pytest.mark.asyncio
     async def test_execute_raises_workflow_timeout_error_on_wait_for_timeout(self) -> None:
@@ -468,6 +470,7 @@ class TestWorkflowTimeout:
 # ---------------------------------------------------------------------------
 # Tests: stop-event graceful cancellation (#143)
 # ---------------------------------------------------------------------------
+
 
 class TestStopEvent:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Flip the `REQUIRE_TLS` default from `False` to `True`, making TLS encryption the secure default for Agamemnon connections. Developers must now explicitly set `REQUIRE_TLS=false` to allow plaintext connections for local development.

## Motivation

Before this change, developers who omitted `REQUIRE_TLS` would silently connect to Agamemnon over plain HTTP, transmitting Bearer API keys in cleartext. This change ensures the secure configuration is the path of least resistance per issue #158 (part of security initiative #92).

## Changes

- **Default flip:** `require_tls: bool = False` → `True` in `Settings`
- **Startup warning:** Added `@model_validator(mode="after")` that logs a `WARNING` when `REQUIRE_TLS=false` is explicitly set
- **Updated configuration:**
  - `.env.example`: Shows `REQUIRE_TLS=false` as a commented-out override with guidance
  - `CLAUDE.md`: Updated environment variable table to reflect new default and usage
  - `pixi.toml`: Bumped version `0.1.0` → `0.2.0` (MINOR: breaking default change per backwards-compat policy)
- **Documentation:**
  - `CHANGELOG.md`: Added "### Changed (breaking)" section documenting the migration
  - `docs/migrations/0.2.md`: Migration guide for operators upgrading from 0.1.x
- **Tests:**
  - `tests/test_config.py` (new): Four comprehensive tests covering default value, warning emission, and client_kwargs propagation

## Testing

All 52 tests pass. New tests verify:
1. `require_tls` defaults to `True`
2. Setting `REQUIRE_TLS=false` emits a `WARNING` with "cleartext" in the message
3. The default setting does not emit spurious warnings
4. `client_kwargs()` correctly propagates the setting

## Migration

Operators upgrading from 0.1.x:
- **Option 1 (recommended):** Use TLS endpoint for `AGAMEMNON_URL` and remove any `REQUIRE_TLS=false` overrides
- **Option 2:** Keep `REQUIRE_TLS=false` in `.env` for local dev only (a `WARNING` is now logged at startup)

See `docs/migrations/0.2.md` for the full migration guide.

Closes #158