### PR TITLE
fix(cli): remove non-functional status/list/cancel stubs (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,13 +141,18 @@ open an issue describing the conflict before proceeding.
 just run workflows/example.yaml    # execute a workflow
 just plan workflows/example.yaml   # dry-run: print what would be created
 just validate workflows/example.yaml  # validate YAML schema only
-just status <workflow-id>          # show running workflow status
-just list                          # list all workflows
-just cancel <workflow-id>          # cancel a running workflow
 just test                          # run pytest
 just lint                          # ruff check
 just format                        # ruff format
 ```
+
+## Planned Features
+
+`status`, `list`, and `cancel` commands are not yet implemented. They
+require a persistent workflow-state backend (no design selected yet —
+not covered by #92, which scopes NATS event ingestion only). Until a
+state backend lands, query ProjectAgamemnon directly for live agent and
+team status.
 
 ## Environment Variables
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,18 +161,12 @@ just run <WORKFLOW>
 # Preview execution plan (dry run)
 just plan <WORKFLOW>
 
-# Check workflow status
-just status <WORKFLOW_ID>
-
-# List all workflows
-just list
-
-# Cancel a running workflow
-just cancel <WORKFLOW_ID>
-
 # Validate workflow YAML
 just validate <WORKFLOW>
 ```
+
+> `status`, `list`, and `cancel` are not yet implemented — see the
+> "Planned Features" section in [CLAUDE.md](./CLAUDE.md).
 
 ### Python Conventions
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,12 @@ just plan workflows/example.yaml
 
 # Validate a workflow file
 just validate workflows/example.yaml
-
-# Check status of a running workflow
-just status <workflow-id>
 ```
 
-> **Note:** `status`, `list`, and `cancel` are currently stubs. They print a
-> placeholder message because persistent workflow-state storage is not yet
-> implemented. Until a state backend lands, query ProjectAgamemnon directly
-> for live agent and team status.
+> **Note:** `status`, `list`, and `cancel` subcommands are not yet
+> implemented — persistent workflow-state storage is out of scope for
+> the current release. Until a state backend lands, query
+> ProjectAgamemnon directly for live agent and team status.
 
 ## Workflow Schema
 

--- a/justfile
+++ b/justfile
@@ -20,21 +20,6 @@ plan WORKFLOW:
     AGAMEMNON_URL={{AGAMEMNON_URL}} NATS_URL={{NATS_URL}} \
         pixi run python -m telemachy.cli plan "{{WORKFLOW}}"
 
-# Show status of a running workflow
-status WORKFLOW_ID:
-    AGAMEMNON_URL={{AGAMEMNON_URL}} \
-        pixi run python -m telemachy.cli status "{{WORKFLOW_ID}}"
-
-# List all workflows (running and completed)
-list:
-    AGAMEMNON_URL={{AGAMEMNON_URL}} \
-        pixi run python -m telemachy.cli list
-
-# Cancel a running workflow
-cancel WORKFLOW_ID:
-    AGAMEMNON_URL={{AGAMEMNON_URL}} \
-        pixi run python -m telemachy.cli cancel "{{WORKFLOW_ID}}"
-
 # Validate a workflow YAML without executing
 validate WORKFLOW:
     pixi run python -m telemachy.cli validate "{{WORKFLOW}}"

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -214,48 +214,6 @@ def validate(
 
 
 @app.command()
-def status(
-    workflow_id: Annotated[str, typer.Argument(help="Workflow ID returned by 'run'")],
-) -> None:
-    """Show the status of a running or completed workflow.
-
-    Note: persistent state storage is not yet implemented.
-    This command is a placeholder for future state backend integration.
-    """
-    console.print(
-        f"[yellow]Status lookup for workflow '{workflow_id}' requires a state backend.[/yellow]\n"
-        "Persistent workflow state storage is not yet implemented.\n"
-        "Check ProjectAgamemnon directly for agent/team status."
-    )
-
-
-@app.command(name="list")
-def list_workflows() -> None:
-    """List all workflows (running and completed).
-
-    Note: persistent state storage is not yet implemented.
-    """
-    console.print(
-        "[yellow]Workflow listing requires a state backend.[/yellow]\n"
-        "Persistent workflow state storage is not yet implemented."
-    )
-
-
-@app.command()
-def cancel(
-    workflow_id: Annotated[str, typer.Argument(help="Workflow ID to cancel")],
-) -> None:
-    """Cancel a running workflow.
-
-    Note: cancellation via state backend is not yet implemented.
-    """
-    console.print(
-        f"[yellow]Cancellation of workflow '{workflow_id}' requires a state backend.[/yellow]\n"
-        "Persistent workflow state storage is not yet implemented."
-    )
-
-
-@app.command()
 def schema(
     output: Path = typer.Option(  # noqa: B008
         Path("schemas/workflow-v1.json"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,3 +193,22 @@ def test_run_dry_run(valid_workflow_file: Path) -> None:
         f"Expected run_workflow to be called with dry_run=True, "
         f"call_args={mock_run.call_args}"
     )
+
+
+# ---------------------------------------------------------------------------
+# TEST 7 — stub commands removed (regression guard for #42)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("removed", ["status", "list", "cancel"])
+def test_removed_stub_commands_absent(removed: str) -> None:
+    """The status/list/cancel stubs were removed; invoking them must fail.
+
+    Guards against the audit finding in issue #42 — these commands were
+    non-functional stubs that created a misleading API surface.
+    """
+    result = runner.invoke(app, [removed, "dummy-arg"])
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for removed command {removed!r}; "
+        f"output:\n{result.output}"
+    )


### PR DESCRIPTION
## Summary

Remove three CLI stub commands (`status`, `list`, `cancel`) that were registered as real Typer commands but only printed "not yet implemented" messages. These stubs created a misleading API surface (POLA violation) and violated YAGNI — the required persistent state backend has no design and is not in scope for #92.

## Changes

- Remove `status()`, `list_workflows()`, and `cancel()` command functions from `src/telemachy/cli.py`
- Remove corresponding justfile recipes (`status`, `list`, `cancel`)
- Update user-facing documentation:
  - `CLAUDE.md`: Remove stubs from "Common Commands" section; add "Planned Features" note
  - `CONTRIBUTING.md`: Remove stub examples; add reference to CLAUDE.md
  - `README.md`: Remove `just status <workflow-id>` example; clarify future status
- Add regression test `test_removed_stub_commands_absent` to prevent stubs from reappearing

## Verification

✓ All 51 tests pass (10 CLI tests, 3 new regression tests)
✓ Lint and type checks clean (`ruff check`, `mypy`)
✓ No `status|list|cancel` commands in `--help` output
✓ No recipes in `justfile --list`
✓ No command references in docs

## Notes

Issue #18 (unused `json`/`sys` imports) was already resolved on main and requires no action. The plan and review for this issue are documented in the issue thread.

Closes #42

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>