### PR TITLE
feat: implement workflow state persistence for status/list/cancel CLI commands

### DIFF
--- a/.claude-followup-47.md
+++ b/.claude-followup-47.md
@@ -1,0 +1,4 @@
+{
+  "follow_ups": [],
+  "rejected": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,13 +192,14 @@ just lint                          # ruff check
 just format                        # ruff format
 ```
 
-## Planned Features
+## Workflow State Persistence
 
-`status`, `list`, and `cancel` commands are not yet implemented. They
-require a persistent workflow-state backend (no design selected yet —
-not covered by #92, which scopes NATS event ingestion only). Until a
-state backend lands, query ProjectAgamemnon directly for live agent and
-team status.
+`status`, `list`, and `cancel` are backed by a file-based `WorkflowState`
+store (`src/telemachy/state_store.py`). `run` persists each workflow's
+state as JSON under `TELEMACHY_STATE_DIR` (default `~/.telemachy/state`);
+`status`/`list` read it back, and `cancel` writes a `<id>.cancel` sentinel
+that the executor's watcher polls. This is independent of the planned NATS
+event ingestion (#92), which scopes live task-lifecycle events only.
 
 ## Testing layers
 
@@ -234,6 +235,16 @@ path that covers permissions, runner labels, and secrets references.
 | `HEALTHCHECK_INTERVAL_SECONDS` | `15` | Seconds between Agamemnon liveness probes during `_monitor_completion`. |
 | `HEALTHCHECK_FAILURE_THRESHOLD` | `2` | Consecutive failed probes before raising `WorkflowConnectivityError`. |
 | `HEALTHCHECK_TIMEOUT_SECONDS` | `5` | Per-probe HTTP timeout (overrides client-wide 30s). |
+| `TELEMACHY_STATE_DIR` | `~/.telemachy/state` | Directory for persisted `WorkflowState` JSON files and `<id>.cancel` sentinels. Read by `status`, `list`, `cancel`. `STATE_DIR` is also accepted as an alias. |
+
+## Implementation Status
+
+### ✅ Implemented
+
+- File-backed `WorkflowState` persistence for `status`/`list`/`cancel`
+  commands (`src/telemachy/state_store.py`). Cancellation propagates via a
+  `<id>.cancel` sentinel polled by `cli.run` (1s interval); the executor's
+  existing `stop_event` is set when the sentinel appears.
 
 <!-- triage: 2026-04-24 myrmidon-swarm implementation pass complete -->
 <!-- 17 PRs merged, all remaining issues tracked individually -->

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 import signal
+import uuid
 from pathlib import Path
 from typing import Annotated
 
@@ -195,6 +197,8 @@ def run(
                 )
 
             async with AgamemnonClient(**settings.client_kwargs()) as client:
+                from telemachy.state_store import FileStateStore
+
                 # Take ONE snapshot, use it for both the --force warning AND
                 # the executor's lookup tables (avoid two round-trips).
                 snapshot: tuple[list, list] | None = None
@@ -216,14 +220,34 @@ def run(
                             "Clean up manually if desired.[/yellow]"
                         )
 
-                executor = WorkflowExecutor(
-                    client,
-                    stop_event=stop_event,
-                    force=force,
-                    existing_snapshot=snapshot,
-                )
-                executor.add_hook("on_task_complete", _on_task_complete)
-                result = await executor.execute(spec)
+                store = FileStateStore(settings.state_dir)
+                workflow_id = str(uuid.uuid4())[:8]
+                console.print(f"[dim]workflow id:[/dim] {workflow_id}")
+
+                async def _watch_cancel() -> None:
+                    while not stop_event.is_set():
+                        if store.is_cancel_requested(workflow_id):
+                            logger.warning("Cancel sentinel detected for %s", workflow_id)
+                            stop_event.set()
+                            return
+                        await asyncio.sleep(1.0)
+
+                watcher = asyncio.create_task(_watch_cancel())
+                try:
+                    executor = WorkflowExecutor(
+                        client,
+                        stop_event=stop_event,
+                        force=force,
+                        existing_snapshot=snapshot,
+                        state_writer=store.save,
+                    )
+                    executor.add_hook("on_task_complete", _on_task_complete)
+                    result = await executor.execute(spec, workflow_id=workflow_id)
+                finally:
+                    watcher.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await watcher
+                    store.clear_cancel(workflow_id)
 
         if result.status == "completed":
             console.print(f"[bold green]Workflow completed.[/bold green] id={result.workflow_id}")
@@ -260,6 +284,84 @@ def validate(
     _validate_workflow_path(workflow_path)
     spec = _load_workflow(workflow_path)
     console.print(f"[bold green]Valid.[/bold green] Workflow: {spec.name}")
+
+
+@app.command()
+def status(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID returned by 'run'")],
+) -> None:
+    """Show the status of a workflow."""
+    from telemachy.state_store import (
+        CorruptStateError,
+        FileStateStore,
+        WorkflowNotFoundError,
+    )
+    store = FileStateStore(settings.state_dir)
+    try:
+        state = store.load(workflow_id)
+    except WorkflowNotFoundError:
+        err_console.print(f"[red]Workflow not found:[/red] {workflow_id}")
+        raise typer.Exit(1) from None
+    except CorruptStateError as exc:
+        err_console.print(f"[red]State file is corrupt:[/red] {exc}")
+        raise typer.Exit(1) from None
+    table = Table(title=f"Workflow {state.workflow_id}")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("name", state.spec.name)
+    table.add_row("status", state.status)
+    table.add_row("started_at", state.started_at or "-")
+    table.add_row("completed_at", state.completed_at or "-")
+    table.add_row("error", state.error or "-")
+    console.print(table)
+
+
+@app.command(name="list")
+def list_workflows() -> None:
+    """List all workflows recorded in the state directory."""
+    from telemachy.state_store import FileStateStore
+    store = FileStateStore(settings.state_dir)
+    states = store.list()
+    if not states:
+        console.print("[dim]No workflows recorded.[/dim]")
+        return
+    table = Table(title="Workflows")
+    for col in ("ID", "Name", "Status", "Started"):
+        table.add_column(col)
+    for s in states:
+        table.add_row(s.workflow_id, s.spec.name, s.status, s.started_at or "-")
+    console.print(table)
+
+
+@app.command()
+def cancel(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID to cancel")],
+) -> None:
+    """Request cancellation of a running workflow."""
+    from telemachy.state_store import (
+        CorruptStateError,
+        FileStateStore,
+        WorkflowNotFoundError,
+    )
+    store = FileStateStore(settings.state_dir)
+    try:
+        state = store.request_cancel(workflow_id)
+    except WorkflowNotFoundError:
+        err_console.print(f"[red]Workflow not found:[/red] {workflow_id}")
+        raise typer.Exit(1) from None
+    except CorruptStateError as exc:
+        err_console.print(f"[red]State file is corrupt:[/red] {exc}")
+        raise typer.Exit(1) from None
+    if state.status in {"completed", "failed", "cancelled"}:
+        console.print(
+            f"[yellow]Workflow {workflow_id} already {state.status} — "
+            "nothing to cancel.[/yellow]"
+        )
+        return
+    console.print(
+        f"[green]Cancellation requested for {workflow_id}.[/green] "
+        f"(detected within ~1s, applied within ~6s)"
+    )
 
 
 @app.command()

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TypedDict
 
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     healthcheck_timeout_seconds: float = 5.0
     log_level: str = "INFO"
     default_workflow_timeout: float = 7200.0
+    state_dir: Path = Field(
+        default=Path.home() / ".telemachy" / "state",
+        validation_alias=AliasChoices("TELEMACHY_STATE_DIR", "STATE_DIR"),
+    )
 
     @model_validator(mode="after")
     def _warn_if_tls_disabled(self) -> Settings:

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -43,6 +43,7 @@ class WorkflowExecutor:
         max_concurrent_provisioning: int = 16,
         force: bool = False,
         existing_snapshot: tuple[list[dict[str, object]], list[dict[str, object]]] | None = None,
+        state_writer: Callable[[WorkflowState], None] | None = None,
     ) -> None:
         self._client = client
         self._poll_interval = poll_interval
@@ -58,6 +59,7 @@ class WorkflowExecutor:
         self._injected_snapshot = existing_snapshot
         self._existing_agents_by_key: dict[str, str] = {}
         self._existing_teams_by_key: dict[str, str] = {}
+        self._state_writer = state_writer
         self._hooks: dict[str, list[Callable[..., Any]]] = {
             "on_task_complete": [],
             "on_task_failed": [],
@@ -75,6 +77,15 @@ class WorkflowExecutor:
             raise ValueError(f"Unknown hook event {event!r}. Valid events: {sorted(self._hooks)}")
         self._hooks[event].append(callback)
 
+    def _persist(self, state: WorkflowState) -> None:
+        """Invoke the state_writer callback if registered. Swallow + log errors."""
+        if self._state_writer is None:
+            return
+        try:
+            self._state_writer(state)
+        except Exception as exc:  # noqa: BLE001 — persistence must not crash a run
+            logger.warning("state persistence failed: %s", exc)
+
     async def _emit(self, event: str, **kwargs: Any) -> None:
         """Fire all callbacks registered for *event*."""
         for cb in self._hooks.get(event, []):
@@ -83,7 +94,7 @@ class WorkflowExecutor:
             else:
                 cb(**kwargs)
 
-    async def execute(self, spec: WorkflowSpec) -> WorkflowState:
+    async def execute(self, spec: WorkflowSpec, workflow_id: str | None = None) -> WorkflowState:
         """Run a full workflow: provision → assign tasks → monitor → teardown."""
         # Emitted-event subjects are scoped to each monitor session (local set
         # in _monitor_completion), so no per-execution instance reset is needed
@@ -94,25 +105,27 @@ class WorkflowExecutor:
             else settings.default_workflow_timeout
         )
         try:
-            return await asyncio.wait_for(self._run(spec), timeout=timeout)
+            return await asyncio.wait_for(self._run(spec, workflow_id), timeout=timeout)
         except TimeoutError as exc:
             raise WorkflowTimeoutError(
                 f"Workflow '{spec.name}' exceeded its execution timeout of {timeout}s"
             ) from exc
 
-    async def _run(self, spec: WorkflowSpec) -> WorkflowState:
+    async def _run(self, spec: WorkflowSpec, workflow_id: str | None = None) -> WorkflowState:
         """Internal execution body — wrapped by execute() with a timeout."""
-        workflow_id = str(uuid.uuid4())[:8]
+        workflow_id = workflow_id or str(uuid.uuid4())[:8]
         state = WorkflowState(
             workflow_id=workflow_id,
             spec=spec,
             status="pending",
             started_at=_now(),
         )
+        self._persist(state)
         logger.info("Starting workflow '%s' (id=%s)", spec.name, workflow_id)
 
         try:
             state.status = "running"
+            self._persist(state)
 
             # Populate idempotency lookup tables (skipped on dry-run or force).
             if not self._dry_run and not self._force:
@@ -136,11 +149,13 @@ class WorkflowExecutor:
             # internal id_map to state.created_agents up front so teardown sees
             # every successfully-created agent even on partial failure (#164).
             await self._provision_agents(spec.agents, spec.name, state)
+            self._persist(state)
 
             # Create teams and submit tasks (respecting dependencies)
             state.created_teams = await self._create_teams(
                 spec.teams, state.created_agents, spec.name
             )
+            self._persist(state)
 
             # Monitor until all tasks reach a terminal state (skipped in dry-run)
             if not self._dry_run:
@@ -162,6 +177,7 @@ class WorkflowExecutor:
             state.status = "cancelled"
             state.completed_at = _now()
             logger.warning("Workflow '%s' was cancelled", spec.name)
+            self._persist(state)
             raise
 
         except Exception as exc:
@@ -172,6 +188,7 @@ class WorkflowExecutor:
             await self._emit("on_workflow_failed", state=state, error=exc)
 
         finally:
+            self._persist(state)
             await self._teardown(state)
 
         return state

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -187,6 +187,7 @@ class WorkflowSpec(BaseModel):
 class WorkflowState(BaseModel):
     """Runtime state for a workflow execution."""
 
+    schema_version: int = 1
     workflow_id: str
     spec: WorkflowSpec
     status: Literal["pending", "running", "completed", "failed", "cancelled"]

--- a/src/telemachy/state_store.py
+++ b/src/telemachy/state_store.py
@@ -1,0 +1,109 @@
+"""File-backed persistence for WorkflowState and cancellation signals."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from telemachy.models import WorkflowState
+
+logger = logging.getLogger(__name__)
+
+_VALID_ID_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+
+class WorkflowNotFoundError(LookupError):
+    """Raised when a workflow_id has no persisted state file."""
+
+
+class CorruptStateError(RuntimeError):
+    """Raised when a state file exists but cannot be parsed (corruption or schema drift)."""
+
+
+def _validate_id(workflow_id: str) -> None:
+    if not workflow_id or len(workflow_id) > 64:
+        raise ValueError(f"invalid workflow_id: {workflow_id!r}")
+    if "\x00" in workflow_id:
+        raise ValueError("workflow_id contains null byte")
+    if not all(c in _VALID_ID_CHARS for c in workflow_id.lower()):
+        raise ValueError(f"workflow_id contains illegal characters: {workflow_id!r}")
+
+
+class FileStateStore:
+    def __init__(self, state_dir: Path) -> None:
+        self._dir = state_dir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self._dir, 0o700)
+        except OSError as exc:
+            logger.debug("could not chmod %s to 0700: %s", self._dir, exc)
+
+    def _state_path(self, workflow_id: str) -> Path:
+        _validate_id(workflow_id)
+        return self._dir / f"{workflow_id}.json"
+
+    def _cancel_path(self, workflow_id: str) -> Path:
+        _validate_id(workflow_id)
+        return self._dir / f"{workflow_id}.cancel"
+
+    def save(self, state: WorkflowState) -> None:
+        target = self._state_path(state.workflow_id)
+        data = state.model_dump_json(indent=2)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{state.workflow_id}.", suffix=".tmp", dir=self._dir
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, target)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    def load(self, workflow_id: str) -> WorkflowState:
+        path = self._state_path(workflow_id)
+        if not path.exists():
+            raise WorkflowNotFoundError(workflow_id)
+        try:
+            return WorkflowState.model_validate_json(path.read_text())
+        except ValidationError as exc:
+            raise CorruptStateError(
+                f"state file {path} is corrupt or from an incompatible schema: {exc}"
+            ) from exc
+
+    def list(self) -> list[WorkflowState]:
+        out: list[WorkflowState] = []
+        for p in sorted(self._dir.glob("*.json")):
+            try:
+                out.append(WorkflowState.model_validate_json(p.read_text()))
+            except (ValidationError, OSError) as exc:
+                logger.warning("skipping unreadable state file %s: %s", p, exc)
+        return out
+
+    def request_cancel(self, workflow_id: str) -> WorkflowState:
+        """Write the cancel sentinel iff workflow is non-terminal. Returns loaded state."""
+        state = self.load(workflow_id)  # raises WorkflowNotFoundError if missing
+        if state.status in {"completed", "failed", "cancelled"}:
+            return state
+        sentinel = self._cancel_path(workflow_id)
+        sentinel.touch(mode=0o600)
+        return state
+
+    def is_cancel_requested(self, workflow_id: str) -> bool:
+        try:
+            return self._cancel_path(workflow_id).exists()
+        except ValueError:
+            return False
+
+    def clear_cancel(self, workflow_id: str) -> None:
+        with contextlib.suppress(ValueError):
+            self._cancel_path(workflow_id).unlink(missing_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,3 +157,42 @@ def test_run_dry_run(valid_workflow_file: Path) -> None:
     assert kwargs.get("dry_run") is True or (len(_args) > 1 and _args[1] is True), (
         f"Expected run_workflow to be called with dry_run=True, call_args={mock_run.call_args}"
     )
+
+
+def test_run_cancel_watcher_cleaned_up_on_normal_completion(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`cli run` must await the watcher task so no 'pending Task' warning fires."""
+    from telemachy.config import Settings
+
+    workflow_yaml = tmp_path / "wf.yaml"
+    workflow_yaml.write_text(yaml.safe_dump(make_workflow_dict(), sort_keys=False))
+
+    monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+    mock_settings = Settings(_env_file=None)
+    monkeypatch.setattr("telemachy.cli.settings", mock_settings)
+
+    mock_state = MagicMock()
+    mock_state.workflow_id = "test-wf-id"
+    mock_state.status = "completed"
+    mock_state.error = None
+
+    # Mock the entire executor + client to avoid network calls
+    with patch("telemachy.cli.AgamemnonClient") as mock_client_cls, \
+         patch("telemachy.cli.WorkflowExecutor") as mock_executor_cls:
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        # cli.run takes an idempotency snapshot via list_agents()/list_teams().
+        mock_client.list_agents = AsyncMock(return_value=[])
+        mock_client.list_teams = AsyncMock(return_value=[])
+        mock_client_cls.return_value = mock_client
+
+        mock_executor = MagicMock()
+        mock_executor.add_hook = MagicMock()
+        mock_executor.execute = AsyncMock(return_value=mock_state)
+        mock_executor_cls.return_value = mock_executor
+
+        result = runner.invoke(app, ["run", str(workflow_yaml)])
+
+    assert result.exit_code == 0

--- a/tests/test_cli_state.py
+++ b/tests/test_cli_state.py
@@ -1,0 +1,163 @@
+"""Tests for the CLI status, list, and cancel commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from telemachy.cli import app
+from telemachy.config import Settings
+from telemachy.models import WorkflowSpec, WorkflowState
+
+runner = CliRunner()
+
+
+def _make_state(
+    workflow_id: str = "test-id",
+    name: str = "test-workflow",
+    status: str = "completed",
+) -> WorkflowState:
+    """Create a minimal WorkflowState for testing."""
+    spec = WorkflowSpec(
+        metadata={"name": name},
+        agents=[],
+        teams=[],
+    )
+    return WorkflowState(
+        workflow_id=workflow_id,
+        spec=spec,
+        status=status,
+        started_at="2026-06-03T10:00:00+00:00",
+    )
+
+
+class TestStatusCommand:
+    def test_status_missing_workflow_exits_1(self, tmp_path: Path, monkeypatch) -> None:
+        """status command exits 1 when workflow not found."""
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["status", "nonexistent-id"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_status_shows_state(self, tmp_path: Path, monkeypatch) -> None:
+        """status command shows persisted workflow state."""
+        from telemachy.state_store import FileStateStore
+
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        store = FileStateStore(tmp_path)
+
+        state = _make_state(workflow_id="test-id", name="my-workflow", status="running")
+        store.save(state)
+
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["status", "test-id"])
+
+        assert result.exit_code == 0
+        assert "test-id" in result.output
+        assert "my-workflow" in result.output
+        assert "running" in result.output
+
+
+class TestListCommand:
+    def test_list_empty(self, tmp_path: Path, monkeypatch) -> None:
+        """list command shows 'No workflows recorded' when state dir is empty."""
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "no workflows recorded" in result.output.lower()
+
+    def test_list_shows_all(self, tmp_path: Path, monkeypatch) -> None:
+        """list command shows all workflows in state dir."""
+        from telemachy.state_store import FileStateStore
+
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        store = FileStateStore(tmp_path)
+
+        state1 = _make_state(workflow_id="wf-1", name="workflow-one", status="completed")
+        state2 = _make_state(workflow_id="wf-2", name="workflow-two", status="failed")
+        store.save(state1)
+        store.save(state2)
+
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 0
+        assert "wf-1" in result.output
+        assert "wf-2" in result.output
+        assert "workflow-one" in result.output
+        assert "workflow-two" in result.output
+
+
+class TestCancelCommand:
+    def test_cancel_running_writes_sentinel(self, tmp_path: Path, monkeypatch) -> None:
+        """cancel command writes sentinel for running workflow."""
+        from telemachy.state_store import FileStateStore
+
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        store = FileStateStore(tmp_path)
+
+        state = _make_state(workflow_id="wf-running", status="running")
+        store.save(state)
+
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["cancel", "wf-running"])
+
+        assert result.exit_code == 0
+        assert "cancellation requested" in result.output.lower()
+        # Verify sentinel was written
+        assert store.is_cancel_requested("wf-running")
+
+    def test_cancel_completed_reports_noop(self, tmp_path: Path, monkeypatch) -> None:
+        """cancel command reports no-op for already completed workflow."""
+        from telemachy.state_store import FileStateStore
+
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        store = FileStateStore(tmp_path)
+
+        state = _make_state(workflow_id="wf-done", status="completed")
+        store.save(state)
+
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["cancel", "wf-done"])
+
+        assert result.exit_code == 0
+        assert "already completed" in result.output.lower()
+        # No sentinel should be written
+        assert not store.is_cancel_requested("wf-done")
+
+    def test_cancel_missing_exits_1(self, tmp_path: Path, monkeypatch) -> None:
+        """cancel command exits 1 when workflow not found."""
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["cancel", "nonexistent-id"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_cancel_corrupt_state_exits_1(self, tmp_path: Path, monkeypatch) -> None:
+        """cancel command exits 1 when state file is corrupt."""
+        from telemachy.state_store import FileStateStore
+
+        monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+        mock_settings = Settings(_env_file=None)
+        store = FileStateStore(tmp_path)
+
+        # Write a corrupt state file
+        corrupt_path = store._state_path("corrupt-id")
+        corrupt_path.write_text("{")
+
+        with patch("telemachy.cli.settings", mock_settings):
+            result = runner.invoke(app, ["cancel", "corrupt-id"])
+
+        assert result.exit_code == 1
+        assert "corrupt" in result.output.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -246,3 +246,25 @@ def test_rate_limit_burst_negative_rejected(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("AGAMEMNON_RATE_LIMIT_BURST", "-5")
     with pytest.raises(pydantic.ValidationError):
         Settings(_env_file=None)
+
+
+def test_state_dir_default_under_home(monkeypatch):
+    monkeypatch.delenv("TELEMACHY_STATE_DIR", raising=False)
+    monkeypatch.delenv("STATE_DIR", raising=False)
+    s = Settings(_env_file=None)
+    assert s.state_dir == Path.home() / ".telemachy" / "state"
+
+
+def test_state_dir_documented_env_name_works(monkeypatch, tmp_path):
+    """TELEMACHY_STATE_DIR (the documented name) overrides the default."""
+    monkeypatch.setenv("TELEMACHY_STATE_DIR", str(tmp_path))
+    s = Settings(_env_file=None)
+    assert s.state_dir == tmp_path
+
+
+def test_state_dir_bare_env_name_also_works(monkeypatch, tmp_path):
+    """STATE_DIR (bare, matching AGAMEMNON_URL convention) also overrides."""
+    monkeypatch.delenv("TELEMACHY_STATE_DIR", raising=False)
+    monkeypatch.setenv("STATE_DIR", str(tmp_path))
+    s = Settings(_env_file=None)
+    assert s.state_dir == tmp_path

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -613,7 +613,7 @@ class TestWorkflowTimeout:
 
         executor = WorkflowExecutor(client, poll_interval=0.01)
 
-        async def slow_run(_spec: object) -> object:
+        async def slow_run(_spec: object, _workflow_id: object = None) -> object:
             import asyncio as _a
 
             await _a.sleep(10)
@@ -795,3 +795,60 @@ async def test_provision_respects_rate_limit_under_gather() -> None:
     await executor.execute(spec)
     elapsed = _time.monotonic() - start
     assert 0.6 <= elapsed <= 4.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: state persistence
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    @pytest.mark.asyncio
+    async def test_state_writer_called_at_each_transition(self) -> None:
+        """state_writer fires for pending, running, and completed."""
+        saved_statuses: list[str] = []
+        client = _make_mock_client()
+        executor = WorkflowExecutor(client, poll_interval=0.01, state_writer=lambda s: saved_statuses.append(s.status))
+        spec = _make_spec()
+        await executor.execute(spec)
+        assert saved_statuses[0] == "pending"
+        assert "running" in saved_statuses
+        assert saved_statuses[-1] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_execute_accepts_workflow_id_override(self) -> None:
+        client = _make_mock_client()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        spec = _make_spec()
+        result = await executor.execute(spec, workflow_id="custom-42")
+        assert result.workflow_id == "custom-42"
+
+    @pytest.mark.asyncio
+    async def test_stop_event_triggers_cancelled_status_and_persists(self) -> None:
+        """stop_event → state.status='cancelled' AND disk reflects it."""
+        import asyncio as _a
+
+        saved_statuses: list[str] = []
+        stop = _a.Event()
+        stop.set()
+        client = _make_mock_client()
+        executor = WorkflowExecutor(
+            client, poll_interval=0.01, stop_event=stop,
+            state_writer=lambda s: saved_statuses.append(s.status),
+        )
+        spec = _make_spec(teardown="never")
+        result = await executor.execute(spec)
+        assert result.status == "cancelled"
+        assert "cancelled" in saved_statuses
+
+    @pytest.mark.asyncio
+    async def test_state_writer_exception_does_not_crash_workflow(self) -> None:
+        """If state_writer raises, the workflow continues."""
+        def broken_writer(_s: object) -> None:
+            raise OSError("disk full")
+
+        client = _make_mock_client()
+        executor = WorkflowExecutor(client, poll_interval=0.01, state_writer=broken_writer)
+        spec = _make_spec()
+        result = await executor.execute(spec)
+        assert result.status == "completed"

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,172 @@
+"""Tests for file-backed state persistence."""
+
+import os
+
+import pytest
+
+from telemachy.models import WorkflowSpec, WorkflowState
+from telemachy.state_store import (
+    CorruptStateError,
+    FileStateStore,
+    WorkflowNotFoundError,
+)
+
+
+def _make_state(workflow_id: str = "test-id") -> WorkflowState:
+    """Create a minimal WorkflowState for testing."""
+    spec = WorkflowSpec(
+        metadata={"name": "test"},
+        agents=[],
+        teams=[],
+    )
+    return WorkflowState(
+        workflow_id=workflow_id,
+        spec=spec,
+        status="pending",
+    )
+
+
+def test_save_load_round_trip(tmp_path):
+    store = FileStateStore(tmp_path)
+    original = _make_state()
+    store.save(original)
+    loaded = store.load(original.workflow_id)
+    assert loaded.workflow_id == original.workflow_id
+    assert loaded.status == original.status
+
+
+def test_save_is_atomic_on_replace_failure(tmp_path, monkeypatch):
+    """If os.replace fails, the target must not exist and tmp must be cleaned."""
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+
+    def failing_replace(src, dst):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+    with pytest.raises(OSError, match="simulated disk full"):
+        store.save(state)
+
+    target = store._state_path(state.workflow_id)
+    assert not target.exists()
+    # Verify no stray .tmp files left behind
+    tmp_files = list(tmp_path.glob(".*.tmp"))
+    assert len(tmp_files) == 0
+
+
+def test_save_sets_0600_file_permissions(tmp_path):
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+    store.save(state)
+    path = store._state_path(state.workflow_id)
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_state_dir_is_0700(tmp_path):
+    store = FileStateStore(tmp_path)
+    assert store._dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_load_missing_raises_not_found(tmp_path):
+    store = FileStateStore(tmp_path)
+    with pytest.raises(WorkflowNotFoundError):
+        store.load("nonexistent")
+
+
+def test_load_corrupt_raises_corrupt_state(tmp_path):
+    store = FileStateStore(tmp_path)
+    path = store._state_path("test-id")
+    path.write_text("{")
+    with pytest.raises(CorruptStateError):
+        store.load("test-id")
+
+
+def test_list_skips_corrupt_files(tmp_path):
+    store = FileStateStore(tmp_path)
+    # Write a valid state
+    state = _make_state("valid-1")
+    store.save(state)
+    # Write a corrupt file
+    corrupt_path = tmp_path / "corrupt-id.json"
+    corrupt_path.write_text("{")
+    # list() should return only the valid state, warning about corrupt
+    states = store.list()
+    assert len(states) == 1
+    assert states[0].workflow_id == "valid-1"
+
+
+def test_list_returns_empty_for_empty_dir(tmp_path):
+    store = FileStateStore(tmp_path)
+    states = store.list()
+    assert states == []
+
+
+def test_request_cancel_writes_sentinel_on_running(tmp_path):
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+    store.save(state)
+    result = store.request_cancel("test-id")
+    assert result.status == "pending"
+    sentinel = store._cancel_path("test-id")
+    assert sentinel.exists()
+
+
+@pytest.mark.parametrize("terminal_status", ["completed", "failed", "cancelled"])
+def test_request_cancel_noop_on_each_terminal_state(tmp_path, terminal_status):
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+    state.status = terminal_status
+    store.save(state)
+    result = store.request_cancel("test-id")
+    assert result.status == terminal_status
+    sentinel = store._cancel_path("test-id")
+    assert not sentinel.exists()
+
+
+def test_request_cancel_missing_raises(tmp_path):
+    store = FileStateStore(tmp_path)
+    with pytest.raises(WorkflowNotFoundError):
+        store.request_cancel("nonexistent")
+
+
+def test_is_cancel_requested_false_when_no_sentinel(tmp_path):
+    store = FileStateStore(tmp_path)
+    assert not store.is_cancel_requested("test-id")
+
+
+def test_is_cancel_requested_true_after_request(tmp_path):
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+    store.save(state)
+    store.request_cancel("test-id")
+    assert store.is_cancel_requested("test-id")
+
+
+def test_clear_cancel_removes_sentinel(tmp_path):
+    store = FileStateStore(tmp_path)
+    state = _make_state()
+    store.save(state)
+    store.request_cancel("test-id")
+    assert store.is_cancel_requested("test-id")
+    store.clear_cancel("test-id")
+    assert not store.is_cancel_requested("test-id")
+
+
+def test_validate_id_rejects_path_traversal(tmp_path):
+    store = FileStateStore(tmp_path)
+    with pytest.raises(ValueError, match="illegal characters"):
+        store.load("../etc/passwd")
+
+
+def test_validate_id_rejects_null_byte(tmp_path):
+    store = FileStateStore(tmp_path)
+    with pytest.raises(ValueError, match="null byte"):
+        store.load("id\x00")
+
+
+def test_validate_id_rejects_empty_and_overlong(tmp_path):
+    store = FileStateStore(tmp_path)
+    with pytest.raises(ValueError, match="invalid workflow_id"):
+        store.load("")
+    with pytest.raises(ValueError, match="invalid workflow_id"):
+        store.load("x" * 65)


### PR DESCRIPTION
## Summary
- Add file-backed state persistence for `status`, `list`, and `cancel` CLI commands
- Workflows are persisted to `~/.telemachy/state/<id>.json` on every status transition
- Cancellation propagates via a sentinel file polled with 1s intervals
- All new tests pass; existing tests remain green

## Test plan
- [x] All 83 unit tests pass
- [x] Lint checks pass (ruff, mypy)
- [x] `status <id>` command shows persisted workflow state
- [x] `list` command enumerates all recorded workflows
- [x] `cancel <id>` command writes sentinel for running workflows
- [x] `cancel <id>` on terminal workflow reports no-op correctly
- [x] State persisted on every transition (pending → running → completed)
- [x] Cancellation sentinel polled and processed correctly
- [x] Watcher task properly cleaned up (no "pending task" warnings)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)