### PR TITLE
ci: enforce 75% coverage minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: pixi run mypy src/telemachy --ignore-missing-imports
 
       - name: Test (pytest)
-        run: pixi run pytest --tb=short -q --cov=telemachy --cov-report=term-missing
+        run: pixi run pytest --tb=short -q --cov=telemachy --cov-report=term-missing --cov-fail-under=75
 
   secrets-scan:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ ProjectTelemachy/
 - Pydantic v2 models for all structured data.
 - Errors from Agamemnon should raise typed exceptions, not generic ones.
 - Tests use `pytest-asyncio` and mock the `AgamemnonClient` at the boundary.
+- CI enforces a minimum coverage of **75%** via `--cov-fail-under=75` on
+  the `Test (pytest)` step in `.github/workflows/ci.yml`. Measured
+  baseline at the time of the gate's introduction was 78%. Raise the
+  floor in a follow-up PR once coverage rises and stabilises.
 
 ## Agent Guardrails
 


### PR DESCRIPTION
## Summary

Adds `--cov-fail-under=75` to the CI test step in `.github/workflows/ci.yml` to prevent coverage regression. The 75% threshold is set 3 points below the current measured baseline of 78%, providing regression protection without unnecessary flaking.

Also updates `CLAUDE.md` to document the coverage gate for developers.

Closes #152