### PR TITLE
feat: add release workflow for GitHub and PyPI publishing

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gitleaks-report
           path: gitleaks.sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify-version:
+    name: verify-version
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          pixi-version: v0.67.2
+          cache: true
+      - name: Resolve target version from tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          ref="${GITHUB_REF#refs/tags/v}"
+          echo "version=${ref}" >> "$GITHUB_OUTPUT"
+          echo "Target release version: ${ref}"
+      - name: Cross-check tag against pyproject.toml and __init__.py
+        env:
+          TARGET: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          pixi run python - <<'PY'
+          import ast, os, pathlib, sys, tomllib
+          target = os.environ["TARGET"]
+          pp = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
+          init = pathlib.Path("src/telemachy/__init__.py").read_text()
+          init_ver = None
+          for node in ast.walk(ast.parse(init)):
+              if isinstance(node, ast.Assign):
+                  for t in node.targets:
+                      if isinstance(t, ast.Name) and t.id == "__version__":
+                          init_ver = ast.literal_eval(node.value)
+          mismatches = []
+          if pp != target:
+              mismatches.append(f"pyproject.toml ({pp}) != tag ({target})")
+          if init_ver != target:
+              mismatches.append(f"__init__.py ({init_ver}) != tag ({target})")
+          if mismatches:
+              print("Version sources disagree:")
+              for m in mismatches:
+                  print(f"  - {m}")
+              sys.exit(1)
+          print(f"All version sources agree on {target}")
+          PY
+
+  build:
+    name: build
+    runs-on: ubuntu-24.04
+    needs: verify-version
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          pixi-version: v0.67.2
+          cache: true
+      - name: Build sdist and wheel
+        run: |
+          pip install build hatchling --quiet
+          python -m build --no-isolation
+      - name: List built artifacts
+        run: ls -la dist/
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemachy-dist-${{ needs.verify-version.outputs.version }}
+          path: dist/*
+          retention-days: 90
+          if-no-files-found: error
+
+  github-release:
+    name: github-release
+    runs-on: ubuntu-24.04
+    needs: [verify-version, build]
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: telemachy-dist-${{ needs.verify-version.outputs.version }}
+          path: dist/
+      - name: Extract changelog section for this version
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          python - <<'PY' > release-notes.md
+          import os, pathlib, re, sys
+          ver = os.environ["VERSION"]
+          text = pathlib.Path("CHANGELOG.md").read_text()
+          pat = re.compile(
+              rf"^## \[{re.escape(ver)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
+              re.MULTILINE | re.DOTALL,
+          )
+          m = pat.search(text)
+          if not m:
+              sys.stderr.write(f"No CHANGELOG entry found for [{ver}]\n")
+              sys.exit(1)
+          sys.stdout.write(m.group(1).strip() + "\n")
+          PY
+      - name: Create GitHub Release with attached artifacts
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: v${{ needs.verify-version.outputs.version }}
+          name: v${{ needs.verify-version.outputs.version }}
+          body_path: release-notes.md
+          files: dist/*
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
+
+  pypi-publish:
+    name: pypi-publish
+    runs-on: ubuntu-24.04
+    needs: [verify-version, build]
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: telemachy-dist-${{ needs.verify-version.outputs.version }}
+          path: dist/
+      - name: Publish to PyPI via Trusted Publishing (OIDC)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/
+          skip-existing: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow (`.github/workflows/release.yml`) that builds
+  sdist+wheel on `v*.*.*` tag pushes, cross-checks the tag against
+  `pyproject.toml` and `__init__.py`, attaches artifacts to a GitHub
+  Release with changelog-derived notes, and publishes to PyPI via
+  Trusted Publishing. Closes #153; part of #92.
 - WorkflowExecutor: declarative YAML-driven multi-agent workflow orchestration
 - AgamemnonClient: async HTTP client for ProjectAgamemnon REST API
 - CLI: `run`, `plan`, `validate`, `status`, `list`, `cancel` commands

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing ProjectTelemachy
 
-This document describes the **manual** release process for
-ProjectTelemachy. Automation is tracked in the issue backlog.
+This document describes the release process for ProjectTelemachy.
+Most steps are automated by `.github/workflows/release.yml`.
 
 ## Version sources of truth
 
@@ -43,10 +43,36 @@ breaking changes in any `MINOR` bump; operators should pin a specific
      `## [X.Y.Z] - YYYY-MM-DD`.
    - Add a fresh empty `## [Unreleased]` block above.
 4. Open a PR titled `chore(release): X.Y.Z`.
-5. After squash-merge, create an annotated git tag on the squash commit:
-   `git tag -a vX.Y.Z -m "Release X.Y.Z"` and push it.
-6. Create a matching GitHub Release referencing the `CHANGELOG.md` entry.
-7. Announce the release in the Odysseus integration channel.
+5. After squash-merge, create an annotated git tag on the squash commit
+   and push it:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+6. The `.github/workflows/release.yml` workflow runs automatically on the
+   tag push: it cross-checks the tag against `pyproject.toml` and
+   `src/telemachy/__init__.py`, builds the sdist+wheel, creates a GitHub
+   Release (body sliced from the matching `## [X.Y.Z]` block in
+   `CHANGELOG.md`) with both artifacts attached, and publishes to PyPI
+   via Trusted Publishing (OIDC).
+7. If the release workflow fails, do **not** delete and re-push the tag.
+   Land a fix on `main`, bump to the next `PATCH`, and tag that.
+8. Announce the release in the Odysseus integration channel.
+
+## Automation
+
+- Workflow: `.github/workflows/release.yml` (triggered on `v*.*.*` tag push).
+- PyPI binding: the `telemachy` project on PyPI must have a Trusted
+  Publisher configured for `HomericIntelligence/ProjectTelemachy`,
+  workflow file `release.yml`, environment `pypi`. Configure once at
+  <https://pypi.org/manage/account/publishing/>. Until this is configured,
+  the `pypi-publish` job will fail with an OIDC token-exchange error —
+  which is the intended fail-loud behaviour, not a silent skip.
+- All third-party actions in the workflow are pinned by 40-char commit
+  SHA; bumping a pin requires re-resolving via
+  `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`.
 
 ## Who approves
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,75 @@
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WF = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# Mirror of the extraction regex used in release.yml's "Extract changelog
+# section" step. Keeping a single canonical pattern here means a drift between
+# the workflow and the test surfaces as an immediate test failure.
+def _extract(version: str, changelog_text: str) -> str | None:
+    pat = re.compile(
+        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    m = pat.search(changelog_text)
+    return m.group(1).strip() if m else None
+
+
+def test_release_workflow_exists() -> None:
+    assert WF.is_file(), "release.yml is missing"
+
+
+def test_release_workflow_triggers_on_version_tag() -> None:
+    data = yaml.safe_load(WF.read_text())
+    # PyYAML parses the unquoted YAML key `on` as the boolean True.
+    on_block = data.get(True, data.get("on"))
+    assert "v*.*.*" in on_block["push"]["tags"]
+
+
+def test_release_workflow_has_expected_jobs() -> None:
+    data = yaml.safe_load(WF.read_text())
+    assert {"verify-version", "build", "github-release", "pypi-publish"} <= set(
+        data["jobs"].keys()
+    )
+
+
+def test_release_workflow_pins_every_action_by_sha() -> None:
+    text = WF.read_text()
+    refs = re.findall(r"uses:\s+([^\s@]+)@([^\s#]+)", text)
+    assert refs, "no `uses:` entries found — regex probably broken"
+    unpinned = [f"{owner}@{ref}" for owner, ref in refs
+                if not re.fullmatch(r"[0-9a-f]{40}", ref)]
+    assert not unpinned, f"unpinned actions: {unpinned}"
+
+
+def test_release_workflow_has_no_continue_on_error() -> None:
+    assert "continue-on-error: true" not in WF.read_text()
+
+
+def test_changelog_extraction_regex_handles_unreleased_block() -> None:
+    # The live CHANGELOG.md is required to have an `## [Unreleased]` heading,
+    # which our regex must locate and extract.
+    body = _extract("Unreleased", CHANGELOG.read_text())
+    assert body is not None and body, "regex failed to extract [Unreleased] block"
+
+
+def test_changelog_extraction_regex_handles_dated_release_heading() -> None:
+    sample = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n### Added\n- next thing\n\n"
+        "## [1.2.3] - 2026-06-03\n\n### Added\n- shipped thing\n\n"
+        "## [1.2.2] - 2026-05-01\n\n### Added\n- older thing\n"
+    )
+    body = _extract("1.2.3", sample)
+    assert body is not None
+    assert "shipped thing" in body
+    assert "older thing" not in body  # must stop at the next `## [` heading
+
+
+def test_changelog_extraction_regex_returns_none_for_missing_version() -> None:
+    sample = "# Changelog\n\n## [Unreleased]\n\n- x\n"
+    assert _extract("9.9.9", sample) is None


### PR DESCRIPTION
## Summary

This PR implements issue #153 by adding a complete release workflow that automates GitHub Release creation and PyPI publishing.

- Adds `.github/workflows/release.yml` with four jobs: `verify-version`, `build`, `github-release`, and `pypi-publish`
- Adds comprehensive tests in `tests/test_release_workflow.py` covering workflow structure, job existence, action pinning, and changelog extraction
- Updates `docs/RELEASING.md` to document the tag-driven automated release process
- Pins `actions/upload-artifact` in `_required.yml:290` to match the SHA used in the release workflow
- Updates `CHANGELOG.md` with the new feature entry

## Key Features

- **Tag-triggered releases**: Activates on `v*.*.*` annotated tag pushes
- **Version verification**: Cross-checks the tag against `pyproject.toml` and `src/telemachy/__init__.py`
- **Artifact building**: Creates sdist+wheel using hatchling (same build path as CI)
- **GitHub Release**: Creates a release with changelog-derived notes and attached artifacts
- **PyPI publishing**: Uses OIDC Trusted Publishing for secure, keyless authentication
- **Fail-loud design**: Missing CHANGELOG entries and version mismatches cause early exit

## All Tests Pass

- 8 new release workflow tests: all pass
- 56 total test suite: all pass
- YAML validation: ✅
- JSON schema validation: ✅
- Build artifact generation: ✅

## Closing Issue

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)