### PR TITLE
docs: document BSD-3-Clause license audit and wire into contributor flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ memory.
   `--no-verify` (it stalls on cold worktrees; document the bypass in the
   PR body).
 - **Never write to `pixi.lock` by hand;** regenerate via `pixi install`.
+- **Always re-run the license audit when adding or major-bumping a
+  runtime dependency.** Update `docs/license-audit.md` in the same
+  PR; re-run `pixi run license-audit` to print the current declared
+  set for cross-checking.
 - **Workflow YAML is a public API** — any change to required fields,
   default values, or schema constraints requires a `MINOR` (additive) or
   `MAJOR` (breaking) version bump per `docs/backwards-compat.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,16 @@ Include: clear title, steps to reproduce, expected vs actual behavior, workflow 
 **Do not open public issues for security vulnerabilities.**
 See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
 
+## Adding or upgrading a runtime dependency
+
+1. Add the dependency to `pixi.toml` `[pypi-dependencies]` with a
+   `>=<lower-bound>` constraint (never `*`).
+2. Run `pixi install` to regenerate `pixi.lock`; commit both files.
+3. Update `docs/license-audit.md` with the dependency's declared
+   license and a yes/no compatibility decision against BSD-3-Clause.
+4. Run `pixi run license-audit` and confirm the printed table
+   matches the Findings section of `docs/license-audit.md`.
+
 ## Code of Conduct
 
 Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -1,61 +1,69 @@
 # Dependency License Compatibility Audit
 
-ProjectTelemachy is distributed under the MIT License (see `LICENSE`).
-This document records the formal license audit of runtime dependencies
-to confirm distribution compatibility.
+ProjectTelemachy is distributed under the BSD 3-Clause License
+(see `LICENSE`). This document records the formal license audit of
+runtime dependencies to confirm distribution compatibility.
 
 ## Audit date
 
-2026-05-16
+2026-06-03
 
 ## Method
 
-1. Enumerate runtime dependencies from `pyproject.toml` and `pixi.toml`
-   `[pypi-dependencies]`.
-2. Resolve each dependency's declared license from its PyPI metadata
-   and source distribution.
-3. Compare each license against the MIT distribution model — any
-   permissive license (MIT, BSD, ISC, Apache 2.0) is compatible;
-   weakly-copyleft licenses (LGPL) require dynamic linking only;
+1. Enumerate runtime dependencies from `pixi.toml`
+   `[pypi-dependencies]` (the authoritative declaration; `pyproject.toml`
+   carries no runtime `dependencies` table — see `pyproject.toml:5-11`).
+2. Resolve each dependency's declared license from its PyPI metadata.
+3. Compare each license against the BSD-3-Clause distribution model —
+   permissive licenses (MIT, BSD, ISC, Apache 2.0) are compatible;
+   weakly-copyleft (LGPL) requires dynamic linking only;
    strong-copyleft (GPL, AGPL) is incompatible.
 
 ## Findings
 
-| Dependency | License | Compatible with MIT distribution? |
+| Dependency | License | Compatible with BSD-3-Clause distribution? |
 | --- | --- | --- |
-| `httpx` | BSD-3-Clause | yes |
 | `pydantic` | MIT | yes |
 | `pydantic-settings` | MIT | yes |
-| `typer` | MIT | yes |
-| `rich` | MIT | yes |
+| `httpx` | BSD-3-Clause | yes |
 | `pyyaml` | MIT | yes |
-| `nats-py` | Apache-2.0 | yes |
+| `rich` | MIT | yes |
+| `typer` | MIT | yes |
 
 All declared runtime dependencies are permissively licensed and
-compatible with redistribution under MIT.
+compatible with redistribution under BSD-3-Clause.
 
 ## Notes
 
-- `nats-py` is currently declared but unused in code (see issues
-  #154 / #196). Once removed it can be dropped from this table.
-- Apache-2.0 dependencies retain their attribution requirements; any
-  redistribution of ProjectTelemachy source or binaries must preserve
-  the upstream `LICENSE` and `NOTICE` files for those dependencies.
-  (Standard pip-installed dependencies are not redistributed by us;
-  they remain on PyPI under their own terms.)
-- Development-only dependencies (`pytest`, `ruff`, `pre-commit`) are
-  not audited here because they do not ship in the runtime artifact.
+- `nats-py` (Apache-2.0) was previously declared but has been removed
+  from `pixi.toml`; it will be re-added when the NATS subscriber lands
+  under #92, at which point this audit must be re-run and the row
+  restored.
+- Apache-2.0 dependencies, when present, retain their attribution
+  requirements; any redistribution of ProjectTelemachy source or
+  binaries must preserve the upstream `LICENSE` and `NOTICE` files
+  for those dependencies. Standard pip-installed dependencies are
+  not redistributed by us; they remain on PyPI under their own terms.
+- Development-only dependencies (`pytest`, `pytest-asyncio`,
+  `pytest-cov`, `ruff`, `mypy`, `types-PyYAML`, `yamllint`) are not
+  audited here because they do not ship in the runtime artifact.
 
 ## Re-audit cadence
 
 This audit is re-run:
 
-1. When a runtime dependency is added.
+1. When a runtime dependency is added (including re-adding `nats-py`
+   under #92).
 2. When a runtime dependency's major version is bumped.
 3. Annually if neither of the above has occurred.
+
+To re-verify mechanically, run `pixi run license-audit`, which
+prints the current `[pypi-dependencies]` table for comparison
+against the Findings section above.
 
 ## See also
 
 - `LICENSE`
-- `pyproject.toml` `[project] dependencies`
+- `pixi.toml` `[pypi-dependencies]`
+- `CONTRIBUTING.md` — runtime-dependency change checklist
 - `docs/backwards-compat.md` — separately governs API compatibility

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,10 +18,11 @@ rich              = ">=13.0"
 typer             = ">=0.12"
 
 [tasks]
-run    = "bash -c 'just run \"$@\"' --"
-test   = "just test"
-lint   = "just lint"
-format = "just format"
+run             = "bash -c 'just run \"$@\"' --"
+test            = "just test"
+lint            = "just lint"
+format          = "just format"
+license-audit   = "python -c \"import tomllib, pathlib; data = tomllib.loads(pathlib.Path('pixi.toml').read_text()); deps = data.get('pypi-dependencies', {}); print('Runtime [pypi-dependencies] (cross-check against docs/license-audit.md):'); [print(f'  {k} = {v!r}') for k, v in deps.items() if k != 'telemachy']\""
 
 [feature.dev.pypi-dependencies]
 pytest          = ">=8.0"


### PR DESCRIPTION
## Summary

Fix `docs/license-audit.md` to correctly identify the project license as BSD 3-Clause (not MIT), remove stale `nats-py` entry, and add mechanical re-verification via `pixi run license-audit` task. Wire the audit into the contributor flow via CLAUDE.md agent guardrails and CONTRIBUTING.md dependency-management checklist for discoverability.

## Changes

- **docs/license-audit.md**: Rewrite to correct license (BSD 3-Clause), remove stale nats-py row, add audit date (2026-06-03), and clarify re-audit cadence with mechanical verification step
- **pixi.toml**: Add `license-audit` task that prints runtime `[pypi-dependencies]` for cross-checking against audit findings
- **CLAUDE.md**: Add agent guardrail bullet requiring license audit update when adding or major-bumping runtime dependencies
- **CONTRIBUTING.md**: Add "Adding or upgrading a runtime dependency" checklist subsection

## Test plan

- ✓ `pixi run license-audit` prints all 6 runtime deps (pydantic, pydantic-settings, httpx, pyyaml, rich, typer)
- ✓ `pixi run test` — all 48 tests pass
- ✓ `just validate workflows/example.yaml` — validates successfully
- ✓ `pixi run lint` — all checks pass
- ✓ All acceptance criteria from issue #156 met

Closes #156