### PR TITLE
feat(security): add Bandit SAST to CI/CD pipeline

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+targets = src/telemachy
+recursive = true

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -293,6 +293,25 @@ jobs:
           path: gitleaks.sarif
           retention-days: 90
 
+  security-sast-scan:
+    name: security/sast-scan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
+      - name: Run Bandit SAST scan (medium+ severity, emit JSON report)
+        run: pixi run python -m bandit -ll --ini .bandit -r src/telemachy -f json -o bandit.json
+      - name: Upload Bandit JSON report
+        if: always() && hashFiles('bandit.json') != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: bandit-report
+          path: bandit.json
+          retention-days: 90
+
   build:
     name: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -297,10 +297,10 @@ jobs:
     name: security/sast-scan
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Run Bandit SAST scan (medium+ severity, emit JSON report)
         run: pixi run python -m bandit -ll --ini .bandit -r src/telemachy -f json -o bandit.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,16 @@ repos:
         entry: '^\s*continue-on-error:\s*true\s*$'
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
+      - id: bandit
+        name: "bandit (SAST, medium+ severity)"
+        description: >
+          AST-based Python security scan. Configured via .bandit INI;
+          findings at severity MEDIUM or higher fail the commit. Add
+          `# nosec <ID>  # <rationale>` inline to suppress per-site.
+        language: system
+        entry: pixi run python -m bandit -ll --ini .bandit
+        files: ^src/telemachy/.*\.py$
+        pass_filenames: false
       - id: require-signed-commits
         name: "require gpg/ssh-signed commits on push"
         description: >

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,11 @@ tested (`tests/test_roadmap.py`).
 - Errors from Agamemnon should raise typed exceptions, not generic ones.
 - Tests use `pytest-asyncio` and mock the `AgamemnonClient` at the boundary.
 - CI enforces a `--cov-fail-under=75` coverage floor (sourced from `pyproject.toml` `[tool.coverage.report]`). Local `just test` does not pass `--cov` by default — reproduce the CI check with `pixi run pytest --cov=telemachy --cov-report=term-missing`.
+- All `src/` Python must pass `pixi run python -m bandit -ll --ini .bandit`. Suppress
+  findings inline with `# nosec <ID>  # <one-line rationale>`, not by widening
+  the `.bandit` `skips` list. When adding a new package under `src/<name>/`,
+  also update the `files:` regex in `.pre-commit-config.yaml` and the `-r`
+  target in the `bandit` task in `pixi.toml`.
 
 ## Agent Guardrails
 
@@ -190,6 +195,8 @@ just validate workflows/example.yaml  # validate YAML schema only
 just test                          # run pytest
 just lint                          # ruff check
 just format                        # ruff format
+just bandit                        # SAST scan (medium+ severity) on src/telemachy
+just check                         # lint + mypy + bandit + test
 ```
 
 ## Planned Features

--- a/justfile
+++ b/justfile
@@ -50,12 +50,16 @@ lint:
 mypy:
     pixi run mypy src/telemachy --ignore-missing-imports
 
+# Run Bandit SAST scan (medium+ severity)
+bandit:
+    pixi run python -m bandit -ll --ini .bandit -r src/telemachy
+
 # Format code with ruff
 format:
     pixi run ruff format src tests
 
-# Run the full local CI suite: lint, mypy, tests
-check: lint mypy test
+# Run the full local CI suite: lint, mypy, bandit, tests
+check: lint mypy bandit test
 
 # Install dev dependencies and set up pre-commit hooks
 bootstrap:

--- a/pixi.lock
+++ b/pixi.lock
@@ -110,26 +110,6 @@ packages:
   - trio>=0.32.0 ; python_full_version >= '3.10' and extra == 'trio'
   - trio>=0.31.0 ; python_full_version < '3.10' and extra == 'trio'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-  md5: d2ffd7602c02f2b316fd921d39876885
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 260182
-  timestamp: 1771350215188
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-  sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
-  md5: 4492fd26db29495f0ba23f146cd5638d
-  depends:
-  - __unix
-  license: ISC
-  purls: []
-  size: 147413
-  timestamp: 1772006283803
 - pypi: https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl
   name: bandit
   version: 1.9.4
@@ -153,6 +133,26 @@ packages:
   - beautifulsoup4>=4.8.0 ; extra == 'test'
   - pylint==1.9.4 ; extra == 'test'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+  sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
+  md5: 4492fd26db29495f0ba23f146cd5638d
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  size: 147413
+  timestamp: 1772006283803
 - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
   name: certifi
   version: 2026.2.25
@@ -655,6 +655,11 @@ packages:
   version: 1.5.4
   sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
+  name: stevedore
+  version: 5.8.0
+  sha256: 88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b
+  requires_python: '>=3.10'
 - pypi: ./
   name: telemachy
   version: 0.1.0
@@ -674,11 +679,6 @@ packages:
   purls: []
   size: 3301196
   timestamp: 1769460227866
-- pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
-  name: stevedore
-  version: 5.8.0
-  sha256: 88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
   name: typer
   version: 0.24.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -35,6 +35,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -64,6 +65,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
@@ -128,6 +130,29 @@ packages:
   purls: []
   size: 147413
   timestamp: 1772006283803
+- pypi: https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl
+  name: bandit
+  version: 1.9.4
+  sha256: f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e
+  requires_dist:
+  - pyyaml>=5.3.1
+  - stevedore>=1.20.0
+  - rich
+  - colorama>=0.3.9 ; sys_platform == 'win32'
+  - pyyaml ; extra == 'yaml'
+  - tomli>=1.1.0 ; python_full_version < '3.11' and extra == 'toml'
+  - gitpython>=3.1.30 ; extra == 'baseline'
+  - sarif-om>=1.0.4 ; extra == 'sarif'
+  - jschema-to-python>=1.2.3 ; extra == 'sarif'
+  - coverage>=4.5.4 ; extra == 'test'
+  - fixtures>=3.0.0 ; extra == 'test'
+  - flake8>=4.0.0 ; extra == 'test'
+  - stestr>=2.5.0 ; extra == 'test'
+  - testscenarios>=0.5.0 ; extra == 'test'
+  - testtools>=2.3.0 ; extra == 'test'
+  - beautifulsoup4>=4.8.0 ; extra == 'test'
+  - pylint==1.9.4 ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
   name: certifi
   version: 2026.2.25
@@ -649,6 +674,11 @@ packages:
   purls: []
   size: 3301196
   timestamp: 1769460227866
+- pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
+  name: stevedore
+  version: 5.8.0
+  sha256: 88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
   name: typer
   version: 0.24.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ run             = "bash -c 'just run \"$@\"' --"
 test            = "just test"
 lint            = "just lint"
 format          = "just format"
+bandit          = "bandit -ll --ini .bandit -r src/telemachy"
 license-audit   = "python -c \"import tomllib, pathlib; data = tomllib.loads(pathlib.Path('pixi.toml').read_text()); deps = data.get('pypi-dependencies', {}); print('Runtime [pypi-dependencies] (cross-check against docs/license-audit.md):'); [print(f'  {k} = {v!r}') for k, v in deps.items() if k != 'telemachy']\""
 
 [feature.dev.pypi-dependencies]
@@ -33,6 +34,7 @@ mypy            = ">=1.10"
 types-PyYAML    = ">=6.0"
 yamllint        = ">=1.26"
 respx           = ">=0.21"
+bandit          = ">=1.7.5"
 
 [environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -15,7 +15,7 @@ class AgentSpec(BaseModel):
     name: str
     program: str = "claude-code"
     model: str | None = None
-    working_dir: str = "/tmp"
+    working_dir: str = "/tmp"  # nosec B108 — ephemeral agent working directory
     runtime: Literal["local", "docker"] = "local"
     docker_image: str | None = None
     cpus: int = 2


### PR DESCRIPTION
## Summary

Add Static Application Security Testing (Bandit) as a required CI check, pre-commit hook, and local development task. Closes the gap where secrets (gitleaks) and dependency (pip-audit) scanning existed but no AST-level analyzer scanned Python source for injection, deserialization, and code-level vulnerabilities.

**Tool choice — Bandit** (PyCQA standard, AST-based, medium+ severity threshold):
- Catches exploitable vulnerabilities: shell injection, eval, pickle, hardcoded secrets
- Suppresses low-severity informational noise  
- Integrates with pixi like ruff/mypy/yamllint (existing pattern)
- Known working in sister repos (prior-learnings knowledge base)

## Test plan

- [x] Local bandit scan passes: `pixi run python -m bandit -ll --ini .bandit -r src/telemachy`
- [x] Pre-commit hook wired and tested: `pixi run pre-commit run bandit --all-files`
- [x] Added to 'just check' local CI gate (runs after mypy)
- [x] All existing tests pass: `pixi run pytest` (48 passed)
- [x] Ruff lint passes: `pixi run ruff check src tests`
- [x] GitHub Actions all SHA-pinned (26/26) — fixed pre-existing upload-artifact@v7 inconsistency
- [x] Suppressed B108 (hardcoded /tmp) in models.py with inline rationale

## Follow-up actions

**Branch protection required checks** — manually update via admin command to include `security/sast-scan`. 
GitHub issue will be opened to track this (prevents "silently forgotten" pattern).

**Rollback path** (if day-1 false positives cannot be inline-suppressed):
Revert only the `security-sast-scan` job block from `.github/workflows/_required.yml` and re-merge, 
leaving `.bandit`/pixi/pre-commit in place for opt-in local use. Reference this PR in that issue.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)