### PR TITLE
feat: implement mid-workflow Agamemnon health checks (#161)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,8 @@ MONITOR_MAX_POLLS=7200
 
 # Default per-workflow execution timeout in seconds
 DEFAULT_WORKFLOW_TIMEOUT=7200
+
+# Health-check (mid-workflow Agamemnon liveness probe) — see #161
+HEALTHCHECK_INTERVAL_SECONDS=15
+HEALTHCHECK_FAILURE_THRESHOLD=2
+HEALTHCHECK_TIMEOUT_SECONDS=5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,9 @@ Integration tests must declare `pytestmark = [pytest.mark.integration, pytest.ma
 | `MONITOR_TIMEOUT_SECONDS` | `3600` | Seconds before workflow monitor times out |
 | `MONITOR_MAX_POLLS` | `7200` | Maximum polling attempts for workflow monitor |
 | `DEFAULT_WORKFLOW_TIMEOUT` | `7200` | Per-workflow execution timeout in seconds |
+| `HEALTHCHECK_INTERVAL_SECONDS` | `15` | Seconds between Agamemnon liveness probes during `_monitor_completion`. |
+| `HEALTHCHECK_FAILURE_THRESHOLD` | `2` | Consecutive failed probes before raising `WorkflowConnectivityError`. |
+| `HEALTHCHECK_TIMEOUT_SECONDS` | `5` | Per-probe HTTP timeout (overrides client-wide 30s). |
 
 <!-- triage: 2026-04-24 myrmidon-swarm implementation pass complete -->
 <!-- 17 PRs merged, all remaining issues tracked individually -->

--- a/src/telemachy/agamemnon_client.py
+++ b/src/telemachy/agamemnon_client.py
@@ -199,6 +199,28 @@ class AgamemnonClient:
         teams: list[dict[str, object]] = response.json().get("teams", [])
         return teams
 
+    async def ping(self, timeout: float = 5.0) -> bool:
+        """Single-shot liveness probe against ``GET /v1/agents``.
+
+        Returns ``True`` iff Agamemnon answers a 2xx response within *timeout*
+        seconds.
+
+        NOTE: This method intentionally bypasses ``_request_with_retry``.
+        The heartbeat loop in ``WorkflowExecutor`` is the retry/threshold
+        gate — wrapping ping() in 3 retries with exponential backoff would
+        swallow up to ~7s of connectivity loss per probe and defeat the
+        purpose of an out-of-band liveness signal. To tune resilience,
+        change ``HEALTHCHECK_FAILURE_THRESHOLD`` /
+        ``HEALTHCHECK_INTERVAL_SECONDS`` rather than this method.
+        """
+        try:
+            resp = await self._http.request("GET", "/v1/agents", timeout=timeout)
+        except httpx.HTTPError:
+            # ConnectError and TimeoutException are both httpx.HTTPError subclasses,
+            # so this single clause covers all transport-level failures.
+            return False
+        return 200 <= resp.status_code < 300
+
     # === Team endpoints ===
 
     async def create_team(self, name: str, agent_ids: list[str]) -> str:

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -39,6 +39,9 @@ class Settings(BaseSettings):
     require_tls: bool = True
     monitor_timeout_seconds: float = 3600.0
     monitor_max_polls: int = 7200
+    healthcheck_interval_seconds: float = 15.0
+    healthcheck_failure_threshold: int = 2
+    healthcheck_timeout_seconds: float = 5.0
     log_level: str = "INFO"
     default_workflow_timeout: float = 7200.0
 

--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import logging
 import time
@@ -24,6 +25,10 @@ _DONE_STATUSES = {"completed", "failed", "error", "cancelled"}
 
 class WorkflowTimeoutError(Exception):
     """Raised when workflow monitoring exceeds the configured timeout or max poll count."""
+
+
+class WorkflowConnectivityError(Exception):
+    """Raised when Agamemnon fails consecutive heartbeat probes during monitoring."""
 
 
 class WorkflowExecutor:
@@ -409,9 +414,66 @@ class WorkflowExecutor:
         callback is scoped to this single monitoring session (#162) — invoking
         _monitor_completion again starts with a fresh set, so duplicate task
         subjects across separate runs each get their callbacks.
+
+        Runs a background heartbeat task to detect Agamemnon connectivity loss
+        mid-workflow. If connectivity is lost, raises WorkflowConnectivityError
+        which sets state.connectivity_failed for teardown.
         """
         logger.info("Monitoring workflow '%s' for completion...", state.spec.name)
+        connectivity_lost = asyncio.Event()
+        heartbeat = asyncio.create_task(
+            self._heartbeat(state.spec.name, connectivity_lost),
+            name=f"telemachy-heartbeat-{state.workflow_id}",
+        )
+        try:
+            await self._poll_until_done(state, connectivity_lost)
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
 
+    async def _heartbeat(self, workflow_name: str, connectivity_lost: asyncio.Event) -> None:
+        """Background task that probes Agamemnon liveness on a timer.
+
+        Calls ping() every healthcheck_interval_seconds and sets connectivity_lost
+        after healthcheck_failure_threshold consecutive failures.
+        """
+        interval = settings.healthcheck_interval_seconds
+        threshold = settings.healthcheck_failure_threshold
+        timeout = settings.healthcheck_timeout_seconds
+        consecutive_failures = 0
+        while not connectivity_lost.is_set():
+            await asyncio.sleep(interval)
+            ok = await self._client.ping(timeout=timeout)
+            if ok:
+                if consecutive_failures:
+                    logger.info(
+                        "Agamemnon connectivity restored for workflow '%s' after %d failure(s)",
+                        workflow_name,
+                        consecutive_failures,
+                    )
+                consecutive_failures = 0
+                continue
+            consecutive_failures += 1
+            logger.warning(
+                "Agamemnon health check failed (%d/%d) for workflow '%s'",
+                consecutive_failures,
+                threshold,
+                workflow_name,
+            )
+            if consecutive_failures >= threshold:
+                connectivity_lost.set()
+                return
+
+    async def _poll_until_done(
+        self, state: WorkflowState, connectivity_lost: asyncio.Event
+    ) -> None:
+        """Poll all team tasks until every task reaches a terminal status.
+
+        Checks the connectivity_lost event at the start of each iteration and
+        raises WorkflowConnectivityError if it is set, storing the failure flag
+        on state so _teardown can honour it under on_completion policy.
+        """
         poll_count = 0
         start_time = time.monotonic()
         timeout = settings.monitor_timeout_seconds
@@ -419,9 +481,16 @@ class WorkflowExecutor:
         emitted_done: set[str] = set()
 
         while True:
+            if connectivity_lost.is_set():
+                state.connectivity_failed = True
+                raise WorkflowConnectivityError(
+                    f"Agamemnon failed {settings.healthcheck_failure_threshold} "
+                    f"consecutive health checks for workflow '{state.spec.name}'"
+                )
             if self._stop_event and self._stop_event.is_set():
                 logger.warning(
-                    "Stop event set — aborting monitoring for workflow '%s'", state.spec.name
+                    "Stop event set — aborting monitoring for workflow '%s'",
+                    state.spec.name,
                 )
                 state.status = "cancelled"
                 return
@@ -480,8 +549,15 @@ class WorkflowExecutor:
 
         policy = state.spec.teardown
 
-        should_teardown = (policy == "on_completion" and state.status == "completed") or (
-            policy == "on_failure" and state.status == "failed"
+        # A connectivity-induced failure should still honour an `on_completion`
+        # policy — the workflow author asked us to clean up after this workflow,
+        # and "Agamemnon went away mid-run" should not leak agents and teams
+        # (see #161). We do NOT extend on_completion to *task* failures, which
+        # are the existing "leave for inspection" behaviour.
+        should_teardown = (
+            (policy == "on_completion" and state.status == "completed")
+            or (policy == "on_completion" and state.connectivity_failed)
+            or (policy == "on_failure" and state.status == "failed")
         )
 
         if not should_teardown:

--- a/src/telemachy/models.py
+++ b/src/telemachy/models.py
@@ -180,3 +180,4 @@ class WorkflowState(BaseModel):
     started_at: str | None = None
     completed_at: str | None = None
     error: str | None = None
+    connectivity_failed: bool = False

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -48,6 +48,7 @@ def _make_mock_client() -> MagicMock:
     client.delete_agent = AsyncMock()
     client.list_agents = AsyncMock(return_value=[])
     client.list_teams = AsyncMock(return_value=[])
+    client.ping = AsyncMock(return_value=True)
     client.create_team = AsyncMock(return_value="team-id-001")
     client.create_task = AsyncMock(return_value="task-id-001")
     client.update_task = AsyncMock()

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,311 @@
+"""Tests for Agamemnon health-check functionality (issue #161)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from telemachy.agamemnon_client import AgamemnonClient
+from telemachy.executor import WorkflowExecutor
+from telemachy.models import WorkflowSpec
+
+
+def _make_spec(
+    agents: list[dict] | None = None,
+    tasks: list[dict] | None = None,
+    teardown: str = "on_completion",
+) -> WorkflowSpec:
+    agents = agents or [{"name": "worker", "runtime": "local"}]
+    tasks = tasks or [{"subject": "Task 1", "description": "Do work", "assign_to": "worker"}]
+    return WorkflowSpec.model_validate(
+        {
+            "apiVersion": "telemachy/v1",
+            "metadata": {"name": "test-wf", "description": "test"},
+            "agents": agents,
+            "teams": [
+                {
+                    "name": "team-a",
+                    "agents": [a["name"] for a in agents],
+                    "tasks": tasks,
+                }
+            ],
+            "teardown": teardown,
+        }
+    )
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock(spec=AgamemnonClient)
+    client.create_agent = AsyncMock(return_value="agent-id-001")
+    client.wake_agent = AsyncMock()
+    client.hibernate_agent = AsyncMock()
+    client.delete_agent = AsyncMock()
+    client.list_agents = AsyncMock(return_value=[])
+    client.ping = AsyncMock(return_value=True)
+    client.create_team = AsyncMock(return_value="team-id-001")
+    client.create_task = AsyncMock(return_value="task-id-001")
+    client.update_task = AsyncMock()
+    client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "completed"}])
+    client.delete_team = AsyncMock()
+    return client
+
+
+# === ping() tests ===
+
+
+class TestPing:
+    @pytest.mark.asyncio
+    async def test_ping_returns_true_on_2xx(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock(spec=AgamemnonClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        client._http = AsyncMock()
+        client._http.request = AsyncMock(return_value=mock_response)
+
+        real_client = AgamemnonClient(url="http://localhost:8080")
+        real_client._client = client._http
+
+        result = await real_client.ping(timeout=5.0)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_ping_returns_false_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock(spec=AgamemnonClient)
+        client._http = AsyncMock()
+        client._http.request = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+
+        real_client = AgamemnonClient(url="http://localhost:8080")
+        real_client._client = client._http
+
+        result = await real_client.ping(timeout=5.0)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_ping_returns_false_on_connect_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = MagicMock(spec=AgamemnonClient)
+        client._http = AsyncMock()
+        client._http.request = AsyncMock(side_effect=httpx.ConnectError("connect failed"))
+
+        real_client = AgamemnonClient(url="http://localhost:8080")
+        real_client._client = client._http
+
+        result = await real_client.ping(timeout=5.0)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_ping_returns_false_on_5xx(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = MagicMock(spec=AgamemnonClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        client._http = AsyncMock()
+        client._http.request = AsyncMock(return_value=mock_response)
+
+        real_client = AgamemnonClient(url="http://localhost:8080")
+        real_client._client = client._http
+
+        result = await real_client.ping(timeout=5.0)
+        assert result is False
+
+
+# === heartbeat threshold tests ===
+
+
+class TestHeartbeatThreshold:
+    @pytest.mark.asyncio
+    async def test_single_ping_failure_does_not_trip_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        client.ping = AsyncMock(side_effect=[False, True, True, True])
+
+        spec = _make_spec()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        # Monitor should complete normally; single ping failure should not trip threshold
+        state = await executor.execute(spec)
+        assert state.status == "completed"
+        assert state.connectivity_failed is False
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_ping_failures_trip_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        # Two consecutive failures should trip threshold
+        client.ping = AsyncMock(side_effect=[False, False])
+        # Never complete tasks so we stay in monitoring
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The exception is caught and the workflow fails
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+
+
+# === end-to-end integration test ===
+
+
+class TestMonitorConnectivity:
+    @pytest.mark.asyncio
+    async def test_monitor_raises_connectivity_error_after_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        # Permanently failing ping
+        client.ping = AsyncMock(return_value=False)
+        # Never complete tasks
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The WorkflowConnectivityError is caught and the workflow fails
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+        assert "consecutive health checks" in state.error
+
+
+# === heartbeat lifecycle tests ===
+
+
+class TestHeartbeatLifecycle:
+    @pytest.mark.asyncio
+    async def test_heartbeat_cancelled_on_normal_completion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+
+        client = _make_mock_client()
+        client.ping = AsyncMock(return_value=True)
+        # Complete immediately
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "completed"}])
+
+        spec = _make_spec()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        assert state.status == "completed"
+        assert state.connectivity_failed is False
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_returns_cleanly_on_connectivity_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        # Two consecutive failures trip the threshold
+        client.ping = AsyncMock(side_effect=[False, False])
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The heartbeat returns cleanly after tripping the threshold,
+        # and the error is caught in the main executor
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+
+
+# === teardown policy regression tests ===
+
+
+class TestTeardownPolicy:
+    @pytest.mark.asyncio
+    async def test_connectivity_error_triggers_teardown_under_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        client.ping = AsyncMock(side_effect=[False, False])
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec(teardown="on_failure")
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The exception becomes "failed" status, which matches the on_failure policy
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+        # Verify teardown WAS called
+        client.delete_agent.assert_called()
+        client.delete_team.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_connectivity_error_triggers_teardown_under_on_completion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Critical resource-leak regression test for issue #161.
+
+        With teardown: on_completion (the default in workflows/example.yaml),
+        a connectivity-induced failure must still trigger teardown.
+        Without this, agents and teams leak.
+        """
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        client.ping = AsyncMock(side_effect=[False, False])
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec(teardown="on_completion")
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The critical fix: connectivity failure should trigger teardown under on_completion
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+        # Verify teardown WAS called (the critical fix for the resource leak)
+        client.delete_agent.assert_called()
+        client.delete_team.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_connectivity_error_skips_teardown_under_never(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_interval_seconds", 0.01)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_failure_threshold", 2)
+        monkeypatch.setattr("telemachy.executor.settings.healthcheck_timeout_seconds", 0.01)
+
+        client = _make_mock_client()
+        client.ping = AsyncMock(side_effect=[False, False])
+        client.get_tasks = AsyncMock(return_value=[{"subject": "Task 1", "status": "running"}])
+
+        spec = _make_spec(teardown="never")
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+
+        state = await executor.execute(spec)
+        # The workflow fails due to connectivity, but teardown is never called
+        assert state.status == "failed"
+        assert state.connectivity_failed is True
+        # Verify teardown was NOT called
+        client.delete_agent.assert_not_called()
+        client.delete_team.assert_not_called()


### PR DESCRIPTION
## Summary

Adds out-of-band connectivity monitoring during workflow execution to detect when Agamemnon becomes unresponsive, distinguishing backend failures from slow task execution.

- AgamemnonClient.ping() — single-shot liveness probe via GET /v1/agents
- _heartbeat background task — probes every 15s, raises WorkflowConnectivityError after 2 consecutive failures
- state.connectivity_failed flag — set before raising so _teardown knows to clean up even under on_completion policy (fixes resource leak)
- Extended _teardown predicate — on_completion now tears down on connectivity failure, not just task success
- 12 test cases covering ping() semantics, threshold logic, lifecycle, and critical teardown policy regression

## Test plan

- [x] All 12 new health check tests pass
- [x] All 48 existing executor tests still pass  
- [x] ruff check and ruff format pass
- [x] Commit is cryptographically signed

Closes #161

🤖 Generated with Claude Code