### PR TITLE
docs: close out release-workflow runbook for #176

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ htmlcov/
 # Build artifacts
 *.whl
 *.tar.gz
+
+# Agent scaffolding (Claude tooling scratch files must not be committed)
+.claude-followup-*.md
+.claude-followup-*.json
+.claude-prompt-*.md
+.claude-pr-review-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sdist+wheel on `v*.*.*` tag pushes, cross-checks the tag against
   `pyproject.toml` and `__init__.py`, attaches artifacts to a GitHub
   Release with changelog-derived notes, and publishes to PyPI via
-  Trusted Publishing. Closes #153; part of #92.
+  Trusted Publishing. Closes #153, #176; part of #92.
 - `docs/ROADMAP.md`, ADR-003, and `v0.1.0`/`v0.2.0`/`v1.0.0` GitHub
   milestones establishing the canonical planning artefact for
   ProjectTelemachy. Regression-tested by `tests/test_roadmap.py`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,9 +11,12 @@ Versions appear in:
 2. `src/telemachy/__init__.py` — `__version__` constant.
 3. `CHANGELOG.md` — `## [X.Y.Z] - YYYY-MM-DD` heading.
 
-All three must agree at release time. A CI sync check exists (see
-`workflows/`) but is currently advisory; the release author is responsible
-for keeping them aligned.
+All three must agree at release time. The `deps-version-sync` job in
+`.github/workflows/_required.yml` enforces this on every PR by parsing
+`pyproject.toml` and `src/telemachy/__init__.py` with `ast.literal_eval`
+and exiting non-zero on mismatch. The release workflow's
+`verify-version` job (`.github/workflows/release.yml:16-62`) is the
+second-layer check that the pushed tag agrees with both sources.
 
 ## Versioning policy
 


### PR DESCRIPTION
## Summary

Close issue #176 by correcting stale documentation and tagging the release workflow in the CHANGELOG.

PR #260 merged on 2026-06-03 (commit fa93375) already implemented the full release workflow with tag-driven automation, artifact uploading, GitHub Release creation, and PyPI Trusted Publishing. This PR closes the remaining gaps:

1. **Correct the stale claim in `docs/RELEASING.md:14-16`**: The docs incorrectly stated version-sync enforcement was "currently advisory." In fact, the `deps-version-sync` job in `.github/workflows/_required.yml` (lines 322-368) enforces it on every PR by parsing `pyproject.toml` and `src/telemachy/__init__.py` with `ast.literal_eval` and exiting non-zero on mismatch.

2. **Tag issue #176 in CHANGELOG.md**: The release workflow entry now correctly lists both `Closes #153, #176`.

## Verification

- [x] Release workflow triggers on `v*.*.*` tag pushes (`.github/workflows/release.yml:5`)
- [x] Build artifacts uploaded (`.github/workflows/release.yml:82`, 90-day retention)
- [x] Artifacts attached to GitHub Release (`.github/workflows/release.yml:128`)
- [x] Published to PyPI via OIDC Trusted Publishing (`.github/workflows/release.yml:148`)
- [x] Release process documented in `docs/RELEASING.md` steps 1-8
- [x] Version-sync enforcement is mandatory, not advisory
- [x] Schema validation checks all `.github/workflows/*.yml` against JSON Schema on every PR

## Acceptance Criteria from Issue #176

- ✓ **Workflow triggered by tag/release event**: `.github/workflows/release.yml:4-6` triggers on `v*.*.*` annotated tags
- ✓ **Build artifacts uploaded**: `.github/workflows/release.yml:82-87` uploads `dist/*` with 90-day retention, fails loudly if build produces no files
- ✓ **Artifacts attached to GitHub Release**: `.github/workflows/release.yml:122-131` attaches `dist/*` to the release
- ✓ **Published to PyPI (no longer manual/undocumented)**: `.github/workflows/release.yml:147-151` publishes via OIDC Trusted Publishing; `docs/RELEASING.md:38-62` documents the operator's release steps

## Remaining External Action

PyPI Trusted Publisher configuration is a one-time manual action on `https://pypi.org/manage/account/publishing/`:
- Project: `telemachy`
- Owner: `HomericIntelligence`
- Repository: `ProjectTelemachy`
- Workflow name: `release.yml`
- Environment name: `pypi`

See `docs/RELEASING.md:71-78` for the operator runbook.

Closes #176