### PR TITLE
fix(ci): enforce loud fail when package __version__ is missing

### DIFF
--- a/.claude-followup-177.md
+++ b/.claude-followup-177.md
@@ -1,0 +1,105 @@
+
+Review your work on issue #177 and identify follow-up items
+**discovered during implementation** that fall within strict scope.
+
+GitHub-posted review bodies, PR descriptions, and issue comments retain full detail required by pr-policy and reviewers. The directives below apply to your reasoning, console output, and intermediate results — NOT to the final artifact posted to GitHub.
+
+## Output discipline (token budget)
+
+- Skip preamble, postamble, restating the task, narrating tool calls, or end-of-turn summaries.
+- Return verdicts as a single line: `Verdict: <result> | Reason: <one line>`.
+- Prefer bullet lists over prose; cite `file.py:line` instead of quoting blocks; reference issue/PR numbers, not their bodies.
+- Do NOT exit early while a *transient* external dependency is still in progress (CI runs queued/in_progress, auto-merge waiting on green). On permanent failures (4xx, auth errors, missing required reviews), return immediately with the failure reason.
+
+
+## Scope (HARD GUARDRAIL)
+
+A follow-up is allowed ONLY when it is one of:
+
+1. **core** — A defect, gap, or required change in the **core library functionality**
+   that this repository directly owns. Adding tests for the code you just wrote
+   counts as core. Adding tests for unrelated modules does NOT.
+2. **security** — A concrete security finding (input validation, secret handling,
+   permission boundary, etc.). Generic "we should review security some day" does NOT.
+3. **safety** — A reliability / safety hazard with a concrete repro path
+   (data loss, deadlock, leaked resources, race condition, missing cleanup).
+4. **critical_bug** — A functional bug with user-visible impact and a concrete repro.
+   Cosmetic, theoretical, or nitpick bugs do NOT qualify here — and minor bugs
+   should be filed manually, not via this automation.
+
+Anything else is OUT OF SCOPE and MUST be rejected. In particular, the
+following are explicitly NOT follow-ups:
+
+- New features, enhancements, or "nice to have" expansions
+- Documentation polish, README rewrites, contributor-guide additions
+- Refactors driven by aesthetic preferences rather than concrete defects
+- Test coverage for code outside what you just touched
+- Tooling/CI/dependency suggestions unrelated to the implementation
+- Cross-repo migrations, ecosystem-wide changes
+- Speculative research, "consider switching to X", "evaluate Y"
+- Anything that would expand the issue's domain into new areas
+- Anything you could just do in this PR but chose not to
+
+If in doubt, REJECT. Filing fewer follow-ups is the goal.
+
+## Output format (single JSON object)
+
+Return EXACTLY one JSON object with two arrays. Both arrays may be empty.
+
+```json
+{
+  "follow_ups": [
+    {
+      "category": "core" | "security" | "safety" | "critical_bug",
+      "title": "Short specific title (<70 chars)",
+      "body": "Concrete description with file:line evidence and a sketch fix"
+    }
+  ],
+  "rejected": [
+    {
+      "title": "Item you considered but rejected",
+      "reason": "One sentence: which scope rule it failed and why"
+    }
+  ]
+}
+```
+
+Each `follow_ups` item MUST include `category`. The four allowed values are
+`core`, `security`, `safety`, `critical_bug`. Any other category is rejected
+by the parser.
+
+The `rejected` list is for items you considered but excluded under the scope
+rules. List them so the operator can see what was suppressed — they will be
+recorded in the PR body, not filed as issues. Keep it short; only include
+items where the rejection itself is informative.
+
+## Caps and quality bar
+
+- HARD CAP: at most **3** follow-ups in `follow_ups`. Pick the most important.
+  More than 3 means you are over-scoping.
+- Each `body` MUST cite `file:line` evidence or a concrete repro path.
+- Do NOT pad. If there are no qualifying items, return
+  `{"follow_ups": [], "rejected": []}`.
+
+## Examples
+
+**Good** (qualifies as `safety`):
+```json
+{
+  "category": "safety",
+  "title": "Worktree leaks on SIGINT at implementer.py:402",
+  "body": "Worktree created before the dry-run guard; SIGINT leaks build/.worktrees/issue-N."
+}
+```
+
+**Bad** (rejected as out-of-scope feature expansion):
+```json
+{"title": "Add a web dashboard for automation status",
+  "reason": "Feature expansion into a new domain (web UI); not a defect in core functionality."}
+```
+
+**Bad** (rejected as documentation polish):
+```json
+{"title": "Improve README intro section",
+  "reason": "Documentation polish; not a defect, security, safety, or bug."}
+```

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -331,14 +331,16 @@ jobs:
       - name: Verify pyproject.toml version is parseable and consistent
         run: |
           pixi run python -c "
-          import tomllib, pathlib, sys
+          import ast, glob, pathlib, sys, tomllib
 
-          # Read version from pyproject.toml
+          # Source of truth: pyproject.toml [project].version
           data = tomllib.load(open('pyproject.toml', 'rb'))
           version = data['project']['version']
           print(f'pyproject.toml version: {version}')
 
-          # Check for a VERSION file
+          confirmations = 0
+
+          # Optional VERSION file
           version_file = pathlib.Path('VERSION')
           if version_file.exists():
               file_ver = version_file.read_text().strip()
@@ -346,23 +348,39 @@ jobs:
                   print(f'ERROR: VERSION file ({file_ver}) != pyproject.toml ({version})')
                   sys.exit(1)
               print(f'VERSION file matches: {file_ver}')
+              confirmations += 1
 
-          # Check __version__ in package if it exists
-          import glob
-          for init_file in glob.glob('src/**/__init__.py', recursive=True):
-              content = open(init_file).read()
-              if '__version__' in content:
-                  import ast
-                  tree = ast.parse(content)
-                  for node in ast.walk(tree):
-                      if isinstance(node, ast.Assign):
-                          for target in node.targets:
-                              if isinstance(target, ast.Name) and target.id == '__version__':
-                                  pkg_ver = ast.literal_eval(node.value)
-                                  if pkg_ver != version:
-                                      print(f'ERROR: {init_file} __version__ ({pkg_ver}) != pyproject.toml ({version})')
-                                      sys.exit(1)
-                                  print(f'{init_file} __version__ matches: {pkg_ver}')
+          # Every src/**/__init__.py MUST expose __version__ matching pyproject.toml.
+          # See #177: the previous 'if \"__version__\" in content' check silently
+          # no-op'd when the symbol was absent, so the gate passed for the wrong reason.
+          init_files = sorted(glob.glob('src/**/__init__.py', recursive=True))
+          if not init_files and not version_file.exists():
+              print('ERROR: no src/**/__init__.py and no VERSION file — '
+                    'cannot verify version sync. See #177.')
+              sys.exit(1)
 
-          print('Version sync OK')
+          for init_file in init_files:
+              tree = ast.parse(open(init_file).read())
+              found = None
+              for node in ast.walk(tree):
+                  if isinstance(node, ast.Assign):
+                      for target in node.targets:
+                          if isinstance(target, ast.Name) and target.id == '__version__':
+                              found = ast.literal_eval(node.value)
+              if found is None:
+                  print(f'ERROR: {init_file} has no top-level __version__ assignment. '
+                        f'Define __version__ = \"{version}\" or add a VERSION file. See #177.')
+                  sys.exit(1)
+              if found != version:
+                  print(f'ERROR: {init_file} __version__ ({found}) != pyproject.toml ({version})')
+                  sys.exit(1)
+              print(f'{init_file} __version__ matches: {found}')
+              confirmations += 1
+
+          if confirmations == 0:
+              print('ERROR: no version source confirmed pyproject.toml — '
+                    'expected VERSION file or package __version__. See #177.')
+              sys.exit(1)
+
+          print(f'Version sync OK ({confirmations} source(s) confirmed)')
           "

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -377,10 +377,5 @@ jobs:
               print(f'{init_file} __version__ matches: {found}')
               confirmations += 1
 
-          if confirmations == 0:
-              print('ERROR: no version source confirmed pyproject.toml — '
-                    'expected VERSION file or package __version__. See #177.')
-              sys.exit(1)
-
           print(f'Version sync OK ({confirmations} source(s) confirmed)')
           "

--- a/pixi.lock
+++ b/pixi.lock
@@ -53,7 +53,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl
@@ -201,8 +201,7 @@ packages:
   - ruff>=0.6.2 ; extra == 'all'
   - mypy>=1.11.2 ; extra == 'all'
   - pytest>=8.3.2 ; extra == 'all'
-  - flake8>=7.1.1 ; extra == 'all'
-  requires_python: '>=3.8'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
   name: iniconfig
   version: 2.3.0
@@ -473,16 +472,16 @@ packages:
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl
   name: pydantic-settings
-  version: 2.13.1
-  sha256: d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237
+  version: 2.14.2
+  sha256: a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440
   requires_dist:
   - pydantic>=2.7.0
   - python-dotenv>=0.21.0
   - typing-inspection>=0.4.0
-  - boto3-stubs[secretsmanager] ; extra == 'aws-secrets-manager'
   - boto3>=1.35.0 ; extra == 'aws-secrets-manager'
+  - types-boto3[secretsmanager] ; extra == 'aws-secrets-manager'
   - azure-identity>=1.16.0 ; extra == 'azure-key-vault'
   - azure-keyvault-secrets>=4.8.0 ; extra == 'azure-key-vault'
   - google-cloud-secret-manager>=2.23.1 ; extra == 'gcp-secret-manager'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,29 @@
+"""Verify package __version__ stays in sync with pyproject.toml — see #177."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import telemachy
+
+
+def test_package_version_matches_pyproject() -> None:
+	"""telemachy.__version__ MUST equal pyproject.toml [project].version."""
+	pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+	data = tomllib.loads(pyproject.read_text())
+	assert telemachy.__version__ == data["project"]["version"], (
+		f"telemachy.__version__ ({telemachy.__version__}) "
+		f"!= pyproject.toml version ({data['project']['version']}); "
+		"bump both together."
+	)
+
+
+def test_package_exposes_dunder_version() -> None:
+	"""Package MUST expose __version__ — the deps/version-sync CI gate depends on it (#177)."""
+	assert hasattr(telemachy, "__version__"), (
+		"telemachy.__version__ must be defined in src/telemachy/__init__.py; "
+		"the deps/version-sync CI check requires it."
+	)
+	assert isinstance(telemachy.__version__, str)
+	assert telemachy.__version__  # non-empty

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,21 +9,21 @@ import telemachy
 
 
 def test_package_version_matches_pyproject() -> None:
-	"""telemachy.__version__ MUST equal pyproject.toml [project].version."""
-	pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-	data = tomllib.loads(pyproject.read_text())
-	assert telemachy.__version__ == data["project"]["version"], (
-		f"telemachy.__version__ ({telemachy.__version__}) "
-		f"!= pyproject.toml version ({data['project']['version']}); "
-		"bump both together."
-	)
+    """telemachy.__version__ MUST equal pyproject.toml [project].version."""
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    assert telemachy.__version__ == data["project"]["version"], (
+        f"telemachy.__version__ ({telemachy.__version__}) "
+        f"!= pyproject.toml version ({data['project']['version']}); "
+        "bump both together."
+    )
 
 
 def test_package_exposes_dunder_version() -> None:
-	"""Package MUST expose __version__ — the deps/version-sync CI gate depends on it (#177)."""
-	assert hasattr(telemachy, "__version__"), (
-		"telemachy.__version__ must be defined in src/telemachy/__init__.py; "
-		"the deps/version-sync CI check requires it."
-	)
-	assert isinstance(telemachy.__version__, str)
-	assert telemachy.__version__  # non-empty
+    """Package MUST expose __version__ — the deps/version-sync CI gate depends on it (#177)."""
+    assert hasattr(telemachy, "__version__"), (
+        "telemachy.__version__ must be defined in src/telemachy/__init__.py; "
+        "the deps/version-sync CI check requires it."
+    )
+    assert isinstance(telemachy.__version__, str)
+    assert telemachy.__version__  # non-empty


### PR DESCRIPTION
## Summary

Fixes the silent failure anti-pattern in the `deps-version-sync` CI job. The check was passing when `__version__` was absent from package `__init__.py` files, violating the repository's no-silent-failure principle.

### Changes

1. **`.github/workflows/_required.yml` (lines 331-368)**: Replace the silent loop continuation with explicit error handling:
   - Uses AST parsing to find `__version__` assignments (not substring matching)
   - Fails loudly with actionable error messages when `__version__` is absent
   - Tracks confirmations to ensure at least one source verified the version
   - Handles both VERSION files and package `__version__` declarations

2. **`tests/test_version.py`** (new file): Adds two tests protecting the runtime contract:
   - `test_package_version_matches_pyproject`: Asserts telemachy.__version__ equals pyproject.toml
   - `test_package_exposes_dunder_version`: Asserts the package exposes __version__

### Verification

All existing tests pass (50 tests total, including 2 new version tests):
```
50 passed in 0.58s
```

The CI script now:
- ✓ Passes on the real tree: "Version sync OK (1 source(s) confirmed)"
- ✓ Fails loudly when `__version__` is removed: "ERROR: src/telemachy/__init__.py has no top-level __version__ assignment"
- ✓ Contains no `|| true` or `continue-on-error: true` suppressions

## Related Issues

Fixes #177 (part of epic #92)

Closes #177