### PR TITLE
fix: replace deprecated asyncio.iscoroutinefunction with inspect (#256)

### DIFF
--- a/src/telemachy/executor.py
+++ b/src/telemachy/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 import uuid
@@ -69,7 +70,7 @@ class WorkflowExecutor:
     async def _emit(self, event: str, **kwargs: Any) -> None:
         """Fire all callbacks registered for *event*."""
         for cb in self._hooks.get(event, []):
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 await cb(**kwargs)
             else:
                 cb(**kwargs)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -438,6 +439,42 @@ class TestHooks:
 
         assert sync_calls == [{"subject": "T1", "status": "completed"}]
         assert async_calls == [{"subject": "T1", "status": "completed"}]
+
+    @pytest.mark.asyncio
+    async def test_emit_uses_inspect_iscoroutinefunction(self, monkeypatch) -> None:
+        """Lock in the #256 migration: _emit must dispatch via inspect, not asyncio."""
+        import inspect as _inspect
+
+        from telemachy import executor as executor_mod
+
+        calls: list[Callable[..., object]] = []
+        real = _inspect.iscoroutinefunction
+
+        def spy(cb: Callable[..., object]) -> bool:
+            calls.append(cb)
+            return real(cb)
+
+        monkeypatch.setattr(executor_mod.inspect, "iscoroutinefunction", spy)
+
+        sync_called = False
+        async_called = False
+
+        def sync_cb(**_: object) -> None:
+            nonlocal sync_called
+            sync_called = True
+
+        async def async_cb(**_: object) -> None:
+            nonlocal async_called
+            async_called = True
+
+        client = _make_mock_client()
+        executor = WorkflowExecutor(client, poll_interval=0.01)
+        executor.add_hook("on_task_complete", sync_cb)
+        executor.add_hook("on_task_complete", async_cb)
+        await executor._emit("on_task_complete", subject="T1", status="completed")
+
+        assert sync_called and async_called
+        assert sync_cb in calls and async_cb in calls
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in the hook dispatcher (`src/telemachy/executor.py:73`). The asyncio alias is deprecated and will be removed in Python 3.16; `inspect.iscoroutinefunction` is the recommended alternative with identical behavior.

Also adds a spy test that locks in this migration and prevents silent regression back to the asyncio alias.

## Issue #256: Follow-up items

### Item 1: Replace deprecated asyncio.iscoroutinefunction ✅
- **Status:** Implemented
- **Changes:** 
  - Added `import inspect` to `src/telemachy/executor.py`
  - Replaced `asyncio.iscoroutinefunction(cb)` with `inspect.iscoroutinefunction(cb)` at line 73
  - Added test `test_emit_uses_inspect_iscoroutinefunction` that verifies the migration via monkeypatch spy

### Item 2: Fix type annotation mismatch in cli.py:200 ✅ (no-op)
- **Status:** Closed as no-op (already resolved by prior work)
- **Evidence:** 
  - Commit `ce87fd7` ("fix(cli): remove non-functional status/list/cancel stubs") removed the `snapshot` variable entirely
  - `grep -rn "snapshot" src/telemachy/` returns no matches
  - No code exists to annotate

## Test Results

All tests pass with coverage above 75% minimum:
- ✅ 64/64 tests passing
- ✅ `test_emit_uses_inspect_iscoroutinefunction` verifies the migration
- ✅ `test_emit_invokes_sync_and_async_callbacks` verifies behavior unchanged
- ✅ All linting checks pass (ruff)

Closes #256