### PR TITLE
chore(ci): bump pixi-version to v0.70.2 to read lock-format v7

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Lint (ruff)
         run: pixi run ruff check src tests
@@ -119,7 +119,7 @@ jobs:
         if: steps.detect.outputs.skip == 'false'
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: pixi install (locked)
         if: steps.detect.outputs.skip == 'false'
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Run pytest
         run: pixi run pytest --tb=short -q --cov=telemachy --cov-report=term-missing
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Validate workflow YAML files are well-formed
         run: |
@@ -242,7 +242,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Run pip-audit on project dependencies
         run: |
@@ -300,7 +300,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Build distribution (hatchling)
         run: |
@@ -326,7 +326,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Verify pyproject.toml version is parseable and consistent
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Resolve target version from tag
         id: resolve
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: Build sdist and wheel
         run: |


### PR DESCRIPTION
## What

Bump `pixi-version` in CI from `v0.67.2` to `v0.70.2` across both workflows:
- `.github/workflows/_required.yml` (7 pins)
- `.github/workflows/release.yml` (2 pins)

No other changes.

## Why

CI pins setup-pixi to **v0.67.2**, which can only read pixi lock-format **v6**. Any v7 lock fails the install step with:

```
Error: × Lock-file version 7 is newer than supported
  help: Maximum supported version: 6 (pixi v0.67.2)
        Cannot continue with --locked or --frozen mode as the lock-file cannot be read.
```

Open PRs **#263, #271, #273, #276** intentionally ship **v7** pixi.lock files (multi-platform macOS/Windows + large mcp/otel dep trees). With the current pin, their entire pipeline dies at `pixi install` — every job reds. This bump unblocks all four.

## Ecosystem consistency

Sibling repo **Agamemnon** already runs **pixi v0.70.2** on main with v7 locks successfully. This is the consistent fix.

## Safety: does not red main

main's own `pixi.lock` is still **v6**. pixi v0.70.2 is backward-compatible. Verified locally with the exact CI command:

- `pixi install --locked` against main's v6 lock → **exit 0** (warn-only: "older format (v6)"; the lock is **not** rewritten, stays v6).
- `pixi install --locked` against #263's v7 lock → **exit 0**, no version error.
- For contrast, v0.67.2 against the v7 lock reproduces the failure above.

So this change is safe on main and unblocks the v7 PRs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>