### PR TITLE
docs(readme): add standardized CI/CD badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProjectTelemachy
 
+[![CI](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml)
+
 A declarative workflow engine for [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon).
 Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, completion monitoring,
 and teardown via the Agamemnon REST API.


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Add a CI workflow status badge to the top of the README, standardizing CI/CD badge
placement across all HomericIntelligence ecosystem repositories.

Generated with [Claude Code](https://claude.com/claude-code)