### PR TITLE
ci: unify job naming to canonical 8-category scheme

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -241,6 +241,19 @@ jobs:
             check-jsonschema --schemafile /tmp/telemachy-schema.json "${workflow_files[@]}"
           fi
 
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [unit-tests, integration-tests]
+    permissions:
+      contents: read
+    steps:
+      - name: Aggregate test gate
+        run: |
+          echo "All test suites (unit-tests, integration-tests) passed."
+          echo "This canonical 'test' check aggregates the split suites for the ecosystem board."
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
@@ -331,6 +344,161 @@ jobs:
         run: |
           pip install build hatchling --quiet
           python -m build --no-isolation
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: telemachy-dist-ci
+          path: dist/*
+          retention-days: 7
+          if-no-files-found: error
+
+  package:
+    name: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: telemachy-dist-ci
+          path: dist/
+      - name: Validate distribution metadata (twine check)
+        run: |
+          pip install twine --quiet
+          ls -la dist/
+          twine check dist/*
+
+  install:
+    name: install
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: telemachy-dist-ci
+          path: dist/
+      - name: Install wheel in a clean venv and smoke-test
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/telemachy-install-venv
+          # shellcheck disable=SC1091
+          . /tmp/telemachy-install-venv/bin/activate
+          pip install --upgrade pip --quiet
+          # ProjectTelemachy is pixi-managed: runtime deps live in pixi.toml
+          # [pypi-dependencies], not pyproject.toml [project.dependencies], so a
+          # clean install must stage those runtime deps alongside the wheel to
+          # reflect how the package is actually consumed. Derive them from
+          # pixi.toml so this stays in sync with the source of truth.
+          python - <<'PY' > /tmp/telemachy-runtime-reqs.txt
+          import re, tomllib
+          deps = tomllib.load(open("pixi.toml", "rb")).get("pypi-dependencies", {})
+          for name, spec in deps.items():
+              if name == "telemachy":
+                  continue
+              ver = spec if isinstance(spec, str) else spec.get("version", "*")
+              # conda-style "*" means "any version" -> bare requirement for pip
+              print(name if ver in ("*", "", None) else f"{name}{ver}")
+          PY
+          echo "Runtime requirements derived from pixi.toml:"
+          cat /tmp/telemachy-runtime-reqs.txt
+          pip install -r /tmp/telemachy-runtime-reqs.txt --quiet
+          wheel=$(ls dist/*.whl)
+          echo "Installing ${wheel} into clean venv"
+          pip install --no-deps "${wheel}"
+          # Import smoke test: the installed package is importable and exposes a version.
+          python -c "import telemachy; print('telemachy', getattr(telemachy, '__version__', 'unknown'), 'importable'); import telemachy.cli"
+          # CLI smoke test: the Typer app responds to --help (exits 0).
+          python -m telemachy.cli --help
+
+  release:
+    name: release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          pixi-version: v0.70.2
+          cache: true
+      - name: Release dry-run (validate changelog + version contract, NO publish)
+        run: |
+          set -euo pipefail
+          # This is a DRY-RUN gate that runs on every push/PR to main so the
+          # ecosystem board has a live 'release' check-run. It validates the
+          # release contract WITHOUT publishing. Actual publishing stays
+          # tag-gated in release.yml (github-release + pypi-publish).
+          pixi run python - <<'PY'
+          import ast, pathlib, re, sys, tomllib
+
+          errors = []
+
+          # 1. pyproject.toml [project].version must be parseable.
+          data = tomllib.load(open("pyproject.toml", "rb"))
+          version = data["project"]["version"]
+          print(f"pyproject.toml version: {version}")
+
+          # 2. src/telemachy/__init__.py __version__ must agree (mirrors release.yml verify-version).
+          init = pathlib.Path("src/telemachy/__init__.py").read_text()
+          init_ver = None
+          for node in ast.walk(ast.parse(init)):
+              if isinstance(node, ast.Assign):
+                  for t in node.targets:
+                      if isinstance(t, ast.Name) and t.id == "__version__":
+                          init_ver = ast.literal_eval(node.value)
+          if init_ver is None:
+              errors.append("src/telemachy/__init__.py has no __version__ assignment")
+          elif init_ver != version:
+              errors.append(f"__init__.py __version__ ({init_ver}) != pyproject.toml ({version})")
+          else:
+              print(f"__init__.py __version__ matches: {init_ver}")
+
+          # 3. CHANGELOG.md must exist and carry a non-empty section the next
+          #    release can publish from. On main (pre-tag) that is the
+          #    'Keep a Changelog' [Unreleased] section; once a tag matching the
+          #    current version is cut, a '## [<version>]' section is also valid.
+          #    release.yml's github-release step slices '## [<tag-version>]' at
+          #    publish time, so we only require a stageable section here — we do
+          #    NOT require a versioned section for an unreleased version (that
+          #    would make this dry-run red on every main commit).
+          changelog = pathlib.Path("CHANGELOG.md")
+          if not changelog.exists():
+              errors.append("CHANGELOG.md is missing")
+          else:
+              text = changelog.read_text()
+              section_pat = re.compile(
+                  rf"^## \[(?:Unreleased|{re.escape(version)})\][^\n]*\n(.*?)(?=^## \[|\Z)",
+                  re.MULTILINE | re.DOTALL,
+              )
+              m = section_pat.search(text)
+              if not m:
+                  errors.append(
+                      "CHANGELOG.md has neither an '## [Unreleased]' nor a "
+                      f"'## [{version}]' section — release notes cannot be staged"
+                  )
+              elif not m.group(1).strip():
+                  errors.append(
+                      "CHANGELOG.md release section is empty — nothing to publish"
+                  )
+              else:
+                  print("CHANGELOG.md has a non-empty stageable release section")
+
+          if errors:
+              print("Release contract validation FAILED:")
+              for e in errors:
+                  print(f"  - {e}")
+              sys.exit(1)
+          print("Release dry-run OK: changelog + version contract valid (no publish performed).")
+          PY
 
   schema-validation:
     name: schema-validation


### PR DESCRIPTION
Unifies ProjectTelemachy's CI job naming to the canonical 8-category scheme used by the [Odysseus ecosystem CI status board](https://github.com/HomericIntelligence/Odysseus/blob/main/docs/ci-naming-convention.md), so the board can show, at a glance, exactly which category is failing.

## Before
Emitting (of 8): **build, test (split only), lint, security**. Missing: **package, install, release** (and `test` had no aggregate check-run — only `unit-tests` / `integration-tests`).

## Changes (all in `.github/workflows/_required.yml`, run on push/PR to `main`)

| Category | Job added | Notes |
|----------|-----------|-------|
| **test** | `test` | Aggregate gate, `needs: [unit-tests, integration-tests]`. Split suites kept as sub-checks. |
| **package** | `package` | `twine check dist/*` against the built sdist/wheel. |
| **install** | `install` | Clean-venv install smoke test: import + `telemachy.cli --help`. |
| **release** | `release` | **Dry-run** gate (version-source agreement + non-empty stageable CHANGELOG section). **No publish.** |

`build` now uploads its dist as `telemachy-dist-ci` so `package`/`install` reuse the artifact instead of rebuilding. `build`, `lint`, and `security/*` were already canonical and are unchanged. The tag-gated publish in `release.yml` (github-release + pypi-publish) is untouched.

## Notable findings
- **`install` for a pixi-managed package:** `pyproject.toml` declares **no `[project.dependencies]`** — runtime deps (httpx, typer, pydantic, rich, mcp, …) live in `pixi.toml [pypi-dependencies]`. A bare `pip install telemachy` is therefore broken in isolation. The `install` job derives the runtime requirements from `pixi.toml`, installs them, then installs the wheel `--no-deps`, so the smoke test reflects how the package is actually consumed (and stays green). If/when the project wants a standalone-pip-installable distribution, declaring `[project.dependencies]` is a separate, follow-up change.
- **`release` dry-run is green on `main`:** it validates the `## [Unreleased]` (or current-version) CHANGELOG section is present and non-empty rather than requiring a `## [0.1.0]` section that does not yet exist pre-tag.

## Discipline
- Emit-before-require: this PR only emits the canonical check-run names on the branch. Ruleset/required-check updates are deferred.
- No silent-failure idioms (`set -euo pipefail`, no `|| true` / `continue-on-error: true`) — passes the repo's own `forbid-suppressions` gate.
- All four new jobs were smoke-tested locally (twine check, clean-venv install + CLI `--help`, release dry-run) before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)