### PR TITLE
ci: fix package job — pin packaging>=24.2 for twine License-File support

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -367,7 +367,12 @@ jobs:
           path: dist/
       - name: Validate distribution metadata (twine check)
         run: |
-          pip install twine --quiet
+          set -euo pipefail
+          # packaging>=24.2 is required: hatchling emits a Metadata-Version 2.4
+          # 'License-File' field, and packaging 24.0 (which twine 6.1.0 may
+          # otherwise resolve) rejects it as a "malformed field 'license-file'".
+          # 24.2 fixed that parser bug. See PEP 639.
+          pip install twine 'packaging>=24.2' --quiet
           ls -la dist/
           twine check dist/*
 


### PR DESCRIPTION
Follow-up to #291 (canonical 8-category CI naming). The new canonical **package** job went **red on main** with:

```
ERROR InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'
```

## Root cause
`pip install twine` on the runner resolved `twine==6.1.0` together with `packaging==24.0`. hatchling emits a `Metadata-Version: 2.4` wheel with a `License-File` field (PEP 639). `packaging 24.0` has a parser bug that rejects that field as "malformed `license-file`"; it was fixed in `packaging 24.2`. (Reproduced locally: `twine 6.1.0 + packaging 24.0` fails; bumping to `packaging>=24.2` passes.)

## Fix
Install `packaging>=24.2` alongside twine in the package job, with `set -euo pipefail`. No `|| true` / `continue-on-error` (passes the repo's own `forbid-suppressions` gate). Verified locally that `twine check` then passes (only the benign `long_description` warnings remain).

This makes the **package** canonical check green so the Odysseus ecosystem board's package cell is accurate.

> Note: `markdownlint` is also red on `main`, but that is pre-existing and unrelated to CI-naming (46 doc-style errors across `.claude-followup-164.md`, `CLAUDE.md`, `CHANGELOG.md`, `docs/**`). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)