### PR TITLE
fix(ci): exclude auto-generated files and .pixi from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,4 @@
+# Auto-generated myrmidon prompt files contain untrusted content
+.claude-prompt-*.md
+.claude-followup-*.md
+.pixi/


### PR DESCRIPTION
Fixes Required Checks CI failure caused by markdownlint errors in auto-generated files.

- `.claude-prompt-*.md` and `.claude-followup-*.md` files contain untrusted GitHub content that cannot be made markdownlint-compliant
- `.pixi/` directory contains vendored license files that trigger MD013

Add `.markdownlintignore` to exclude all three patterns from CI linting.