### PR TITLE
chore(rename): drop Project prefix → Telemachy

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,7 +1,7 @@
-# ProjectTelemachy Custom Skills
+# Telemachy Custom Skills
 
 This directory holds repository-specific Claude / Hephaestus skills for
-ProjectTelemachy-specific workflows. Skills are markdown documents that
+Telemachy-specific workflows. Skills are markdown documents that
 describe **how to perform a recurring task** in this repository; they
 complement the global Hephaestus skill library by capturing knowledge
 that is too narrow for ecosystem-wide reuse.

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# ProjectTelemachy — environment variable reference
+# Telemachy — environment variable reference
 # Copy this file to .env and fill in the values for your environment.
 
 # Agamemnon API base URL

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -404,7 +404,7 @@ jobs:
           # shellcheck disable=SC1091
           . /tmp/telemachy-install-venv/bin/activate
           pip install --upgrade pip --quiet
-          # ProjectTelemachy is pixi-managed: runtime deps live in pixi.toml
+          # Telemachy is pixi-managed: runtime deps live in pixi.toml
           # [pypi-dependencies], not pyproject.toml [project.dependencies], so a
           # clean install must stage those runtime deps alongside the wheel to
           # reflect how the package is actually consumed. Derive them from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
-# AGENTS.md — ProjectTelemachy
+# AGENTS.md — Telemachy
 
 This document specifies the multi-agent coordination protocols for
-ProjectTelemachy within the HomericIntelligence distributed agent mesh.
+Telemachy within the HomericIntelligence distributed agent mesh.
 
 ## Role
 
-ProjectTelemachy is the declarative workflow engine: it parses YAML
+Telemachy is the declarative workflow engine: it parses YAML
 workflows, provisions agents and teams via ProjectAgamemnon's REST API,
 assigns dependency-ordered tasks, monitors completion, and tears down
 resources.
@@ -28,7 +28,7 @@ off (see "Handoff" below).
 
 | Agent | Owns | Must not do |
 | --- | --- | --- |
-| ProjectTelemachy | workflow YAML interpretation, dependency ordering, teardown policy | spawn agents directly (always via Agamemnon) |
+| Telemachy | workflow YAML interpretation, dependency ordering, teardown policy | spawn agents directly (always via Agamemnon) |
 | ProjectAgamemnon | agent / team / task lifecycle, HMAS orchestration | parse workflow YAML |
 | ProjectNestor | research and ideation upstream | execute workflows |
 | ProjectArgus | observability, log aggregation | mutate state in Agamemnon |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See `docs/backwards-compat.md`.
   Trusted Publishing. Closes #153, #176; part of #92.
 - `docs/ROADMAP.md`, ADR-003, and `v0.1.0`/`v0.2.0`/`v1.0.0` GitHub
   milestones establishing the canonical planning artefact for
-  ProjectTelemachy. Regression-tested by `tests/test_roadmap.py`.
+  Telemachy. Regression-tested by `tests/test_roadmap.py`.
   Closes #167; part of #92.
 - WorkflowExecutor: declarative YAML-driven multi-agent orchestration with
   dependency-respecting task assignment, HTTP polling for completion, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# ProjectTelemachy — CLAUDE.md
+# Telemachy — CLAUDE.md
 
 ## Project Overview
 
-ProjectTelemachy is a declarative workflow engine that automates multi-agent workflows by calling the
+Telemachy is a declarative workflow engine that automates multi-agent workflows by calling the
 ProjectAgamemnon REST API. Users define workflows in YAML; Telemachy parses them, provisions agents and
 teams via Agamemnon, assigns tasks with dependency ordering, monitors execution by polling
 Agamemnon's REST API (NATS-based event monitoring is planned but not yet wired up), and
@@ -107,7 +107,7 @@ teardown: on_completion | on_failure | never
 ## Repository Structure
 
 ```
-ProjectTelemachy/
+Telemachy/
 ├── src/
 │   └── telemachy/
 │       ├── __init__.py           # version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ProjectTelemachy
+# Contributing to Telemachy
 
-Thank you for your interest in contributing to ProjectTelemachy! This is the workflow
+Thank you for your interest in contributing to Telemachy! This is the workflow
 execution engine for the [HomericIntelligence](https://github.com/HomericIntelligence)
 distributed agent mesh — it runs, plans, monitors, and cancels named workflow YAML files
 against Agamemnon's REST API. (A NATS-based event channel is planned — see issue #92 — but is not yet wired up.)
@@ -38,8 +38,8 @@ sending a PR that alters planned scope.
 
 ```bash
 # Clone the repository
-git clone https://github.com/HomericIntelligence/ProjectTelemachy.git
-cd ProjectTelemachy
+git clone https://github.com/HomericIntelligence/Telemachy.git
+cd Telemachy
 
 # Activate the Pixi environment
 pixi shell
@@ -83,7 +83,7 @@ work (#92) and is not currently used by the engine.
 
 Before starting work:
 
-- Browse [existing issues](https://github.com/HomericIntelligence/ProjectTelemachy/issues)
+- Browse [existing issues](https://github.com/HomericIntelligence/Telemachy/issues)
 - Comment on an issue to claim it before starting work
 - Create a new issue if one doesn't exist for your contribution
 
@@ -280,4 +280,4 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ---
 
-Thank you for contributing to ProjectTelemachy!
+Thank you for contributing to Telemachy!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ProjectTelemachy
+# Telemachy
 
-[![CI](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectTelemachy/actions/workflows/ci.yml)
+[![CI](https://github.com/HomericIntelligence/Telemachy/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/Telemachy/actions/workflows/ci.yml)
 
 A declarative workflow engine for [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon).
 Define multi-agent workflows in YAML — Telemachy handles provisioning, task orchestration, completion monitoring,
@@ -46,7 +46,7 @@ just validate workflows/example.yaml
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the canonical roadmap —
 current, next, and future releases plus known limitations. Outstanding
 work (NATS subscriber, state backend for `status`/`list`/`cancel`) is
-tracked under epic [#92](https://github.com/HomericIntelligence/ProjectTelemachy/issues/92).
+tracked under epic [#92](https://github.com/HomericIntelligence/Telemachy/issues/92).
 
 ## Workflow Schema
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,7 +110,7 @@ When you report a vulnerability:
 
 ## Security Best Practices
 
-When contributing to ProjectTelemachy:
+When contributing to Telemachy:
 
 - Validate workflow YAML schemas before execution
 - Sanitize workflow parameters and step inputs

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
-# Releasing ProjectTelemachy
+# Releasing Telemachy
 
-This document describes the release process for ProjectTelemachy.
+This document describes the release process for Telemachy.
 Most steps are automated by `.github/workflows/release.yml`.
 
 ## Version sources of truth
@@ -20,7 +20,7 @@ second-layer check that the pushed tag agrees with both sources.
 
 ## Versioning policy
 
-ProjectTelemachy follows [Semantic Versioning 2.0.0](https://semver.org/).
+Telemachy follows [Semantic Versioning 2.0.0](https://semver.org/).
 The public surface area governed by SemVer is:
 
 - The **workflow YAML schema** (`apiVersion: telemachy/v1`, field names,
@@ -68,7 +68,7 @@ breaking changes in any `MINOR` bump; operators should pin a specific
 
 - Workflow: `.github/workflows/release.yml` (triggered on `v*.*.*` tag push).
 - PyPI binding: the `telemachy` project on PyPI must have a Trusted
-  Publisher configured for `HomericIntelligence/ProjectTelemachy`,
+  Publisher configured for `HomericIntelligence/Telemachy`,
   workflow file `release.yml`, environment `pypi`. Configure once at
   <https://pypi.org/manage/account/publishing/>. Until this is configured,
   the `pypi-publish` job will fail with an OIDC token-exchange error —

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
-# ProjectTelemachy Roadmap
+# Telemachy Roadmap
 
-This roadmap is the authoritative planning artefact for ProjectTelemachy.
+This roadmap is the authoritative planning artefact for Telemachy.
 It captures **what is shipping now, what is shipping next, and what we
 know is not yet built**. Every row links to an issue, an ADR, or both.
 
@@ -17,17 +17,17 @@ Conventions:
 | --- | --- | --- | --- |
 | HTTP-polling task monitoring | Shipped (default) | — | [ADR-001](adr/001-http-polling-monitoring.md) |
 | Agamemnon-exclusive backend | Shipped | — | [ADR-002](adr/002-decouple-from-maestro.md) |
-| Secure TLS default (`REQUIRE_TLS=true`) | Shipped | [#158](https://github.com/HomericIntelligence/ProjectTelemachy/issues/158) | — |
-| Release workflow (PyPI + GH Release) | Shipped | [#153](https://github.com/HomericIntelligence/ProjectTelemachy/issues/153) | — |
-| 75% coverage gate | Shipped | [#152](https://github.com/HomericIntelligence/ProjectTelemachy/issues/152) | — |
-| Strict-audit remediation epic | In progress | [#92](https://github.com/HomericIntelligence/ProjectTelemachy/issues/92) | — |
+| Secure TLS default (`REQUIRE_TLS=true`) | Shipped | [#158](https://github.com/HomericIntelligence/Telemachy/issues/158) | — |
+| Release workflow (PyPI + GH Release) | Shipped | [#153](https://github.com/HomericIntelligence/Telemachy/issues/153) | — |
+| 75% coverage gate | Shipped | [#152](https://github.com/HomericIntelligence/Telemachy/issues/152) | — |
+| Strict-audit remediation epic | In progress | [#92](https://github.com/HomericIntelligence/Telemachy/issues/92) | — |
 
 ## Next Release (v0.2.0)
 
 | Work | Status | Issue | ADR |
 | --- | --- | --- | --- |
-| NATS subscriber for task-lifecycle events (supersedes ADR-001) | Planned | [#92](https://github.com/HomericIntelligence/ProjectTelemachy/issues/92) | ADR-001 → to be superseded |
-| Roadmap & milestones (this artefact) | In progress | [#167](https://github.com/HomericIntelligence/ProjectTelemachy/issues/167) | [ADR-003](adr/003-roadmap-artifact.md) |
+| NATS subscriber for task-lifecycle events (supersedes ADR-001) | Planned | [#92](https://github.com/HomericIntelligence/Telemachy/issues/92) | ADR-001 → to be superseded |
+| Roadmap & milestones (this artefact) | In progress | [#167](https://github.com/HomericIntelligence/Telemachy/issues/167) | [ADR-003](adr/003-roadmap-artifact.md) |
 
 ## Future (v1.0.0 and beyond)
 

--- a/docs/adr/001-http-polling-monitoring.md
+++ b/docs/adr/001-http-polling-monitoring.md
@@ -2,12 +2,12 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-16
-- **Deciders:** ProjectTelemachy maintainers
+- **Deciders:** Telemachy maintainers
 - **Context tags:** monitoring, NATS, executor
 
 ## Context
 
-ProjectTelemachy's `WorkflowExecutor` needs to detect when assigned tasks
+Telemachy's `WorkflowExecutor` needs to detect when assigned tasks
 complete, so it can release dependent tasks and ultimately tear the
 workflow down per the declared teardown policy.
 
@@ -28,7 +28,7 @@ chose HTTP polling.
 
 ## Decision
 
-ProjectTelemachy monitors task completion by polling
+Telemachy monitors task completion by polling
 ProjectAgamemnon's REST API at the interval defined by
 `MONITOR_TIMEOUT_SECONDS` / `MONITOR_MAX_POLLS`. The NATS-based monitor
 path remains aspirational and is tracked by repository issues; this ADR

--- a/docs/adr/002-decouple-from-maestro.md
+++ b/docs/adr/002-decouple-from-maestro.md
@@ -2,12 +2,12 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-16
-- **Deciders:** ProjectTelemachy maintainers
+- **Deciders:** Telemachy maintainers
 - **Context tags:** orchestration, Agamemnon, maestro
 
 ## Context
 
-ProjectTelemachy originally supported two backends:
+Telemachy originally supported two backends:
 
 1. ai-maestro — the previous orchestrator in the HomericIntelligence
    ecosystem (see Odysseus `docs/adr/006-decouple-from-ai-maestro.md`).
@@ -20,7 +20,7 @@ ai-maestro has been removed from the mesh.
 
 ## Decision
 
-ProjectTelemachy targets **ProjectAgamemnon exclusively** as its execution
+Telemachy targets **ProjectAgamemnon exclusively** as its execution
 backend. The `maestro_client.py` module is retained only as a thin
 deprecation stub and will be removed in a future major release.
 

--- a/docs/adr/003-roadmap-artifact.md
+++ b/docs/adr/003-roadmap-artifact.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-06-03
-- **Deciders:** ProjectTelemachy maintainers
+- **Deciders:** Telemachy maintainers
 - **Context tags:** planning, governance, docs
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records
 
 This directory holds Architecture Decision Records (ADRs) for
-ProjectTelemachy. ADRs are append-only documents capturing **why** a
+Telemachy. ADRs are append-only documents capturing **why** a
 significant architectural choice was made.
 
 ## Convention

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-ProjectTelemachy records all workflow execution events to a structured JSONL audit log when configured with
+Telemachy records all workflow execution events to a structured JSONL audit log when configured with
 `AUDIT_LOG_PATH`. The audit log serves as a tamper-evident record of:
 
 - **Who** ran the workflow (hostname, user account)

--- a/docs/backwards-compat.md
+++ b/docs/backwards-compat.md
@@ -1,7 +1,7 @@
 # Backwards Compatibility Policy
 
 This document defines what backwards compatibility means for
-ProjectTelemachy and how breaking changes are handled.
+Telemachy and how breaking changes are handled.
 
 ## Public surface area (governed by SemVer)
 

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -22,7 +22,7 @@ When a CI job fails at "Set up job" or any pre-checkout step:
 ### 1. Pull the Logs
 
 ```bash
-gh run view <RUN-ID> --log-failed --repo HomericIntelligence/ProjectTelemachy
+gh run view <RUN-ID> --log-failed --repo HomericIntelligence/Telemachy
 ```
 
 Look for the specific error message. Common patterns:
@@ -42,8 +42,8 @@ at the time of the failure. Note the incident ID if one matches the failure time
 **If the run is recent (< 90 days old):**
 
 ```bash
-gh run rerun <RUN-ID> --failed --repo HomericIntelligence/ProjectTelemachy
-gh run watch <RUN-ID> --repo HomericIntelligence/ProjectTelemachy
+gh run rerun <RUN-ID> --failed --repo HomericIntelligence/Telemachy
+gh run watch <RUN-ID> --repo HomericIntelligence/Telemachy
 ```
 
 Wait for the re-run to complete. If it passes, the failure was transient.
@@ -53,7 +53,7 @@ Wait for the re-run to complete. If it passes, the failure was transient.
 Trigger a fresh `workflow_dispatch` run on the same commit SHA:
 
 ```bash
-gh workflow run ci.yml --ref <COMMIT-SHA> --repo HomericIntelligence/ProjectTelemachy
+gh workflow run ci.yml --ref <COMMIT-SHA> --repo HomericIntelligence/Telemachy
 ```
 
 Then observe the new run. If it passes, the failure was transient.
@@ -126,7 +126,7 @@ grep -oE '\$\{\{[[:space:]]*secrets\.[A-Z_]+[[:space:]]*\}\}' \
 Compare the referenced secret names against the configured secrets in the repo:
 
 ```bash
-gh secret list --repo HomericIntelligence/ProjectTelemachy --json name --jq '.[].name' | sort -u
+gh secret list --repo HomericIntelligence/Telemachy --json name --jq '.[].name' | sort -u
 ```
 
 **What to look for:**

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -1,7 +1,7 @@
 # Definition of Done
 
 This document captures what "done" means for a feature, bug-fix, or
-documentation change in ProjectTelemachy. It complements `CONTRIBUTING.md`.
+documentation change in Telemachy. It complements `CONTRIBUTING.md`.
 
 ## Done — feature
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
-# Installing and Upgrading ProjectTelemachy
+# Installing and Upgrading Telemachy
 
-ProjectTelemachy is a Python package distributed primarily for the
+Telemachy is a Python package distributed primarily for the
 HomericIntelligence ecosystem. This document explains how to install it
 outside the pinned `pixi` development environment.
 
@@ -9,8 +9,8 @@ outside the pinned `pixi` development environment.
 ### 1. `pixi` (development; recommended)
 
 ```bash
-git clone https://github.com/HomericIntelligence/ProjectTelemachy.git
-cd ProjectTelemachy
+git clone https://github.com/HomericIntelligence/Telemachy.git
+cd Telemachy
 pixi install
 pixi run just test
 ```
@@ -34,7 +34,7 @@ declared in `pyproject.toml`; CI does not run this path.
 ### 3. `pip install` from a release tag (operator)
 
 ```bash
-pip install "git+https://github.com/HomericIntelligence/ProjectTelemachy@vX.Y.Z"
+pip install "git+https://github.com/HomericIntelligence/Telemachy@vX.Y.Z"
 ```
 
 This installs the `telemachy` CLI and library into the active Python
@@ -48,7 +48,7 @@ Add to your `pyproject.toml`:
 ```toml
 [project]
 dependencies = [
-    "telemachy @ git+https://github.com/HomericIntelligence/ProjectTelemachy@vX.Y.Z",
+    "telemachy @ git+https://github.com/HomericIntelligence/Telemachy@vX.Y.Z",
 ]
 ```
 
@@ -75,7 +75,7 @@ pip uninstall telemachy            # if installed via pip
 rm -rf <repo-checkout>/.pixi
 ```
 
-No persistent data is stored by ProjectTelemachy itself — workflow state
+No persistent data is stored by Telemachy itself — workflow state
 lives in ProjectAgamemnon.
 
 ## Troubleshooting

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -1,6 +1,6 @@
 # Dependency License Compatibility Audit
 
-ProjectTelemachy is distributed under the BSD 3-Clause License
+Telemachy is distributed under the BSD 3-Clause License
 (see `LICENSE`). This document records the formal license audit of
 runtime dependencies to confirm distribution compatibility.
 
@@ -46,7 +46,7 @@ compatible with redistribution under BSD-3-Clause.
   under #92, at which point this audit must be re-run and the row
   restored.
 - Apache-2.0 dependencies, when present, retain their attribution
-  requirements; any redistribution of ProjectTelemachy source or
+  requirements; any redistribution of Telemachy source or
   binaries must preserve the upstream `LICENSE` and `NOTICE` files
   for those dependencies. Standard pip-installed dependencies are
   not redistributed by us; they remain on PyPI under their own terms.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP (Model Context Protocol) Server
 
-The ProjectTelemachy MCP server (`telemachy-mcp`) provides read-only access to live Agamemnon state during development.
+The Telemachy MCP server (`telemachy-mcp`) provides read-only access to live Agamemnon state during development.
 It allows AI agents working in this repository to query agents and tasks without requiring direct HTTP access to the
 Agamemnon API.
 
@@ -22,7 +22,7 @@ No configuration is required beyond the environment variables listed below.
 
 ## Environment Variables
 
-The MCP server reuses the following environment variables from ProjectTelemachy's standard configuration:
+The MCP server reuses the following environment variables from Telemachy's standard configuration:
 
 - `AGAMEMNON_URL` (default: `http://localhost:8080`) — Agamemnon base URL
 - `AGAMEMNON_API_KEY` (optional) — Agamemnon API key (if auth is enabled)
@@ -74,6 +74,6 @@ The following are explicitly deferred or out-of-scope:
 
 ## Implementation
 
-See [issue #173](https://github.com/ProjectTelemachy/telemachy/issues/173) for full details. The implementation uses a
+See [issue #173](https://github.com/Telemachy/telemachy/issues/173) for full details. The implementation uses a
 plan-owned `Dispatcher` seam in `src/telemachy/mcp_server.py` to keep tests isolated from the MCP SDK's private
 internals.

--- a/src/telemachy/__init__.py
+++ b/src/telemachy/__init__.py
@@ -1,4 +1,4 @@
-"""ProjectTelemachy — declarative workflow engine for ProjectAgamemnon."""
+"""Telemachy — declarative workflow engine for ProjectAgamemnon."""
 
 from telemachy.agamemnon_client import AgamemnonClient, AgamemnonError
 from telemachy.config import Settings

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -1,4 +1,4 @@
-"""Typer CLI for ProjectTelemachy."""
+"""Typer CLI for Telemachy."""
 
 from __future__ import annotations
 

--- a/src/telemachy/config.py
+++ b/src/telemachy/config.py
@@ -25,7 +25,7 @@ class AgamemnonClientKwargs(TypedDict):
 
 
 class Settings(BaseSettings):
-    """Application settings for ProjectTelemachy."""
+    """Application settings for Telemachy."""
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -46,7 +46,7 @@ def test_roadmap_references_outstanding_work_items() -> None:
 def test_roadmap_uses_canonical_remote_url() -> None:
     # Guard against the fork-URL defect seen in the prior plan iteration.
     text = _read()
-    bad = re.findall(r"https://github\.com/(?!HomericIntelligence/ProjectTelemachy)[^/\s)]+/ProjectTelemachy", text)
+    bad = re.findall(r"https://github\.com/(?!HomericIntelligence/Telemachy)[^/\s)]+/Telemachy", text)
     assert not bad, f"docs/ROADMAP.md links to non-canonical repo URLs: {bad}"
 
 


### PR DESCRIPTION
## Rename: HomericIntelligence/ProjectTelemachy → HomericIntelligence/Telemachy

This PR is the follow-up to the GitHub-side `gh repo rename` (URL flipped in
Phase 1; this PR finishes the rename *inside* the repo).

### Diff summary

```
 26 files changed, 66 insertions(+), 66 deletions(-)
```

### Files updated

```
.claude/skills/README.md
.env.example
.github/workflows/_required.yml
AGENTS.md
CHANGELOG.md
CLAUDE.md
CONTRIBUTING.md
README.md
SECURITY.md
docs/RELEASING.md
docs/ROADMAP.md
docs/adr/001-http-polling-monitoring.md
docs/adr/002-decouple-from-maestro.md
docs/adr/003-roadmap-artifact.md
docs/adr/README.md
docs/audit-log.md
docs/backwards-compat.md
docs/ci-triage.md
docs/definition-of-done.md
docs/install.md
docs/license-audit.md
docs/mcp.md
src/telemachy/__init__.py
src/telemachy/cli.py
src/telemachy/config.py
tests/test_roadmap.py
```

### What this PR does NOT change

- Container names (`telemachy-exporter`, `telemachy-loki`, ...) where already
  lowercase — preserved (they already matched the bare form).
- `CHANGELOG.md` historical entries — preserved verbatim per
  [ADR-014](../Odysseus/blob/main/docs/adr/014-runnable-evidence-for-metric-claims.md) (evidence integrity).
- Branch protection / rulesets / secrets / environments — apply manually on
  the renamed repo (see Phase 6).

### Verification

- `grep -RIE 'ProjectTelemachy|projecttelemachy|PROJECTTELEMACHY' .` returns **zero** hits
  (Phase 4 pre-commit guard).
- CI green (lint, integration tests, package, dashboard, exporter).

### Followups (separate PRs)

1. `HomericIntelligence/Odyssey` — meta-repo PR updating `.gitmodules`, `justfile`,
   `docker-compose.e2e.yml`, `tools/github/*.sh`, `scripts/install/*`,
   `e2e/start-*.sh`, `docs/{architecture,onboarding,deployment,repo-conventions}.md`,
   `.github/PULL_REQUEST_TEMPLATE/atlas-*.md`.
2. Apply the same `gh repo rename + sed` sequence to the next prefixed repo
   in the queue (tools/github/rename-repo.sh is parametrized).
3. `HomericIntelligence/Hephaestus` and `HomericIntelligence/Athena` (`ProjectHephaestus` carve-out) —
   not a straight rename; handle as a separate procedure.