### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,35 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
Migrate .claude/settings.json from the stale hephaestus@ProjectHephaestus plugin to the Athena marketplace.

The hephaestus utilities were carved out to HomericIntelligence/Athena (marketplace name: Athena, 23 per-skill plugins). This PR:

- Removes the stale hephaestus@ProjectHephaestus enabledPlugins key
- Adds the 23 <skill>@Athena per-skill plugin keys
- Registers the Athena marketplace under extraKnownMarketplaces
- Preserves all other settings

Verified: valid JSON, hephaestus reference gone, exactly 23 @Athena keys matching the expected set, Athena marketplace registered.

Closes #302