### PR TITLE
[CI] Drop retired macos-13 runner from pixi-check matrix

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, macos-13, windows-2022]
+        os: [ubuntu-24.04, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Skip if no pixi.toml


### PR DESCRIPTION
The non-required `pixi-check (macos-13)` matrix job never gets a runner (GitHub retired the macos-13 hosted image). Every "Required Checks" run stays open ~24h until timeout-cancel, and every PR shows UNSTABLE merge state even with all 12 required checks green (#296/#297/#298/#305 all exhibit this).

One-line change: remove `macos-13` from the pixi-check matrix in `.github/workflows/_required.yml`. macOS coverage is retained via macos-14.

Closes #306