### PR TITLE
ci: prepare Telemachy for merge queue

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,15 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 - PR title should be clear and descriptive
 - Tests and linting must pass
 
+### Merge queue rollout
+
+Telemachy's required checks support GitHub merge groups, but queue activation
+is a separate, staged operator action. See
+[`docs/ci/merge-queue.md`](docs/ci/merge-queue.md) for the approved queue
+policy, activation gate, smoke check, and rollback procedure. Until activation
+is recorded in issue #308, contributors must not assume that enabling
+auto-merge has placed a pull request in the queue.
+
 ### Changelog discipline
 
 Any PR that changes user-visible behavior — CLI flags, workflow YAML

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,133 @@
+# Merge queue rollout
+
+Telemachy's `main` branch is prepared for a staged GitHub merge-queue rollout.
+The queue must not be activated until the readiness pull request has merged,
+strict review has passed, and a representative smoke-check pull request is ready.
+
+The repository-level `homeric-main-baseline` ruleset remains the source of truth
+for branch protection. Activation must append one `merge_queue` rule to that
+ruleset without changing its conditions, bypass actors, enforcement mode, or
+existing rules.
+
+## Required checks
+
+The queue must preserve all required GitHub Actions contexts:
+
+- `lint`
+- `unit-tests`
+- `integration-tests`
+- `security/dependency-scan`
+- `security/secrets-scan`
+- `build`
+- `schema-validation`
+- `deps/version-sync`
+- `test`
+- `package`
+- `install`
+- `release`
+
+`.github/workflows/_required.yml` emits these contexts for `push`,
+`pull_request`, and `merge_group` `checks_requested` events. The tag-only
+`.github/workflows/release.yml` publisher must remain tag-only; it must never run
+for merge groups.
+
+## Approved policy
+
+The rule appended during activation must match this object exactly.
+
+<!-- merge-queue-rule -->
+```json
+{
+  "type": "merge_queue",
+  "parameters": {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 10,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 5
+  }
+}
+```
+
+This means at most 10 queue entries may request builds concurrently, at most 5
+entries may merge as a group, and a group may proceed with one entry after the
+5-minute wait. Required checks have 60 minutes to report. `ALLGREEN` requires
+every pull request represented in the group to satisfy the required checks.
+
+## Post-merge activation
+
+Activation is an operator step, not part of the readiness pull request.
+
+1. Confirm the readiness change is on `main` and its required checks are green.
+2. Confirm a representative pull request is ready to enter the queue.
+3. Re-read the live ruleset and save a restorable payload.
+4. Append only the approved `merge_queue` rule and update the full ruleset.
+5. Re-read the ruleset, then queue the smoke pull request with squash.
+6. Confirm a `merge_group` run emits and passes all required contexts before the
+   pull request merges.
+7. Record the ruleset response, workflow run, and queued merge in issue #308.
+
+The following commands preserve the full live ruleset and refuse to append a
+second queue rule. Review both generated JSON files before running the `PUT`.
+
+```bash
+REPO=HomericIntelligence/Telemachy
+RULESET_NAME=homeric-main-baseline
+RULESET_ID="$(gh api "repos/${REPO}/rulesets" \
+  --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")"
+test -n "${RULESET_ID}"
+
+gh api "repos/${REPO}/rulesets/${RULESET_ID}" \
+  | jq '{name, target, enforcement, bypass_actors, conditions, rules}' \
+  > /tmp/telemachy-ruleset-before.json
+
+jq -e '[.rules[] | select(.type == "merge_queue")] | length == 0' \
+  /tmp/telemachy-ruleset-before.json
+
+jq '.rules += [{
+  "type": "merge_queue",
+  "parameters": {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 10,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 5
+  }
+}]' /tmp/telemachy-ruleset-before.json \
+  > /tmp/telemachy-ruleset-with-queue.json
+
+gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" \
+  --input /tmp/telemachy-ruleset-with-queue.json
+```
+
+After the update, verify the live policy and run the smoke check:
+
+```bash
+gh api "repos/${REPO}/rulesets/${RULESET_ID}" \
+  --jq '.rules[] | select(.type == "merge_queue")'
+
+gh pr merge --auto --squash <SMOKE-PR> --repo "${REPO}"
+gh run list --repo "${REPO}" --workflow _required.yml --event merge_group \
+  --limit 1 --json databaseId,event,headSha,status,conclusion,url
+```
+
+Do not remove or rename any required context during activation. The queue rule
+does not carry a separate check list; it relies on the existing
+`required_status_checks` rule in the same ruleset.
+
+## Rollback
+
+If the rule update does not preserve the ruleset or the smoke check cannot emit
+all required contexts, stop the rollout and restore the reviewed snapshot:
+
+```bash
+gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" \
+  --input /tmp/telemachy-ruleset-before.json
+```
+
+Re-read the ruleset after rollback and confirm the `merge_queue` rule is absent
+while all pre-existing required contexts and protection rules remain intact.

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -36,6 +36,9 @@ documentation change in Telemachy. It complements `CONTRIBUTING.md`.
 - [ ] Workflow runs successfully on the PR.
 - [ ] Required check list in branch protection updated if a job was
       renamed/added.
+- [ ] Required-check workflow changes pass `tests/test_merge_queue.py` and
+      preserve the staged activation contract in
+      [`docs/ci/merge-queue.md`](ci/merge-queue.md).
 - [ ] Time and resource impact noted in the PR description.
 
 ## Not done

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -1,0 +1,113 @@
+"""Regression tests for GitHub merge-queue readiness."""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
+MERGE_QUEUE_RUNBOOK = REPO_ROOT / "docs" / "ci" / "merge-queue.md"
+
+REQUIRED_CONTEXTS = {
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "package",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+}
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict), f"{path} must contain a workflow mapping"
+    return data
+
+
+def _on_block(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the Actions trigger block despite PyYAML's YAML 1.1 `on` coercion."""
+    on_block = workflow.get(True, workflow.get("on"))
+    assert isinstance(on_block, dict), "workflow `on` block must be a mapping"
+    return on_block
+
+
+def _targets_main_changes(on_block: dict[str, Any]) -> bool:
+    for event in ("pull_request", "push"):
+        config = on_block.get(event)
+        if not isinstance(config, dict):
+            continue
+        branches = config.get("branches")
+        if branches is not None and "main" in branches:
+            return True
+        if branches is None and event == "pull_request":
+            return True
+        if branches is None and event == "push" and "tags" not in config:
+            return True
+    return False
+
+
+def test_required_context_workflows_support_merge_group_checks_requested() -> None:
+    suppliers: dict[str, set[str]] = {}
+
+    for path in sorted(WORKFLOWS_DIR.glob("*.y*ml")):
+        workflow = _load_workflow(path)
+        jobs = workflow.get("jobs", {})
+        job_names = {
+            job.get("name", job_id) for job_id, job in jobs.items() if isinstance(job, dict)
+        }
+        supplied_contexts = REQUIRED_CONTEXTS & job_names
+        on_block = _on_block(workflow)
+        if not supplied_contexts or not _targets_main_changes(on_block):
+            continue
+
+        suppliers[path.name] = supplied_contexts
+        assert on_block.get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{path} supplies required contexts but does not handle merge_group/checks_requested"
+        )
+
+    emitted = set().union(*suppliers.values()) if suppliers else set()
+    assert emitted == REQUIRED_CONTEXTS
+
+
+def test_release_publisher_remains_tag_only() -> None:
+    on_block = _on_block(_load_workflow(RELEASE_WORKFLOW))
+
+    assert on_block["push"] == {"tags": ["v*.*.*"]}
+    assert "pull_request" not in on_block
+    assert "merge_group" not in on_block
+
+
+def test_merge_queue_runbook_pins_approved_activation_policy() -> None:
+    assert MERGE_QUEUE_RUNBOOK.is_file(), "merge-queue activation runbook is missing"
+    text = MERGE_QUEUE_RUNBOOK.read_text()
+    match = re.search(
+        r"<!-- merge-queue-rule -->\s*```json\n(?P<policy>.*?)\n```",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "runbook is missing its machine-readable merge-queue rule"
+
+    assert json.loads(match.group("policy")) == {
+        "type": "merge_queue",
+        "parameters": {
+            "check_response_timeout_minutes": 60,
+            "grouping_strategy": "ALLGREEN",
+            "max_entries_to_build": 10,
+            "max_entries_to_merge": 5,
+            "merge_method": "SQUASH",
+            "min_entries_to_merge": 1,
+            "min_entries_to_merge_wait_minutes": 5,
+        },
+    }
+    for context in REQUIRED_CONTEXTS:
+        assert f"`{context}`" in text


### PR DESCRIPTION
## Summary

- trigger the required-check workflow for `merge_group` / `checks_requested`
  while preserving its existing `push` and `pull_request` behavior
- add regression coverage for all 12 live required contexts and keep the
  tag-only release publisher isolated from merge-group events
- document the approved staged activation policy, smoke check, and rollback
  without changing the live GitHub ruleset

Closes #308

Umbrella rollout: https://github.com/HomericIntelligence/Odysseus/issues/386

## Live baseline reviewed

- default branch: `main`
- active ruleset: `homeric-main-baseline` (repository ruleset `15556487`)
- required contexts preserved: `lint`, `unit-tests`, `integration-tests`,
  `security/dependency-scan`, `security/secrets-scan`, `build`,
  `schema-validation`, `deps/version-sync`, `test`, `package`, `install`, and
  `release`
- live merge-queue rule count remains `0`; this PR performs no ruleset write

## Test plan

- [x] `pixi run pytest tests/test_merge_queue.py -q` — 3 passed
- [x] `just check` — ruff passed, mypy passed, Bandit found no medium/high
  issues, 286 passed and 3 skipped
- [x] CI coverage command — 286 passed, 3 skipped, 88.86% coverage (75%
  required)
- [x] pre-commit on all five changed files — all applicable hooks passed
- [x] markdownlint-cli2 on changed Markdown — 0 errors
- [x] GitHub workflow JSON Schema validation — `ok -- validation done`
- [x] `yamllint -c .yamllint.yaml .` — exited 0 with seven pre-existing
  line-length warnings
- [x] `just validate workflows/example.yaml` — `Valid. Workflow:
  codebase-audit`

Pytest prints a post-summary OpenTelemetry exporter warning (`ValueError: I/O
operation on closed file`) after the successful test result; it does not change
the zero exit status and is pre-existing behavior.

## Risk and rollout

- Backwards compatible: yes
- Requires schema bump: no
- Changelog: waived as internal CI/tooling only
- CI impact: the existing required-check job set runs once more for each merge
  group; no required job or context is added, removed, or renamed
- Activation remains a post-merge operator step. Follow
  `docs/ci/merge-queue.md` only after strict review and a representative smoke
  PR are ready. The approved queue policy is squash, ALLGREEN, 10 maximum queue
  builds, 5 maximum merged entries per group, 1 minimum entry, 5-minute wait,
  and 60-minute check timeout.

## Review focus

- exact required-context preservation
- exclusion of the tag-only publishing workflow from `merge_group`
- GET/preserve/append/PUT activation and rollback integrity
- focused regression tests for workflow and policy drift
