### PR TITLE
ci: prepare Telemachy merge queue policy

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.ref }}

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -307,10 +307,10 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif
           else
             gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif
           fi
 
       - name: Upload Gitleaks SARIF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,15 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 - PR title should be clear and descriptive
 - Tests and linting must pass
 
+### Merge queue rollout
+
+Telemachy's required checks support GitHub merge groups, but queue activation
+is a separate, staged operator action. See
+[`docs/ci/merge-queue.md`](docs/ci/merge-queue.md) for the approved queue
+policy, activation gate, smoke check, and rollback procedure. Until activation
+is recorded in issue #308, contributors must not assume that enabling
+auto-merge has placed a pull request in the queue.
+
 ### Changelog discipline
 
 Any PR that changes user-visible behavior — CLI flags, workflow YAML

--- a/configs/github/merge-queue-policy.json
+++ b/configs/github/merge-queue-policy.json
@@ -1,0 +1,30 @@
+{
+  "repository": "HomericIntelligence/Telemachy",
+  "target_branch": "main",
+  "required_contexts": [
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "package",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests"
+  ],
+  "merge_queue_rule": {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }
+}

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,8 +1,11 @@
 # Merge queue rollout
 
 Telemachy's `main` branch is prepared for a staged GitHub merge-queue rollout.
-The queue must not be activated until the readiness pull request has merged,
-strict review has passed, and a representative smoke-check pull request is ready.
+An independent human must review the workflow changes before the readiness pull
+request may merge; following this runbook does not satisfy that review gate. The
+queue must not be activated until the readiness pull request has merged, strict
+review findings are resolved, and a representative smoke-check pull request is
+ready.
 
 The repository-level `homeric-main-baseline` ruleset remains the source of truth
 for branch protection. Activation must append one `merge_queue` rule to that
@@ -93,45 +96,147 @@ gh api "repos/${REPO}/rulesets/${RULESET_ID}" \
       == [$policy[0].merge_queue_rule]
     '
 
-gh pr merge --auto --squash <SMOKE-PR> --repo "${REPO}"
-RUN_ID="$(gh run list --repo "${REPO}" --workflow _required.yml \
-  --event merge_group --limit 1 --json databaseId,event \
-  --jq 'map(select(.event == "merge_group"))[0].databaseId')"
-test -n "${RUN_ID}"
+SMOKE_PR=123  # Replace with the designated smoke pull request number.
+OWNER="${REPO%%/*}"
+NAME="${REPO#*/}"
+REQUESTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PR_HEAD_SHA="$(gh pr view "${SMOKE_PR}" --repo "${REPO}" \
+  --json headRefOid --jq '.headRefOid')"
+test -n "${PR_HEAD_SHA}"
+printf 'smoke_pr=%s requested_at=%s pr_head_sha=%s\n' \
+  "${SMOKE_PR}" "${REQUESTED_AT}" "${PR_HEAD_SHA}"
 
-gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
-  --jq '{id,event,head_sha,status,conclusion,html_url}'
+gh pr merge --auto --squash "${SMOKE_PR}" --repo "${REPO}"
+
+# Poll the designated PR until GitHub records its actual queue entry. The entry
+# provides both the authoritative enqueue time and that entry's queue head SHA.
+QUEUE_ENTRY=""
+for attempt in {1..60}; do
+  QUEUE_ENTRY="$(gh api graphql \
+    -f owner="${OWNER}" -f name="${NAME}" -F number="${SMOKE_PR}" \
+    -f query='
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            mergeQueueEntry {
+              enqueuedAt
+              headCommit { oid }
+            }
+          }
+        }
+      }
+    ' --jq '
+      .data.repository.pullRequest.mergeQueueEntry
+      | select(. != null and .headCommit != null)
+      | {enqueuedAt, queueHeadSha: .headCommit.oid}
+    ')"
+  [[ -n "${QUEUE_ENTRY}" ]] && break
+  sleep 10
+done
+test -n "${QUEUE_ENTRY}"
+
+ENQUEUED_AT="$(jq -r '.enqueuedAt' <<<"${QUEUE_ENTRY}")"
+QUEUE_HEAD_SHA="$(jq -r '.queueHeadSha' <<<"${QUEUE_ENTRY}")"
+CURRENT_PR_HEAD_SHA="$(gh pr view "${SMOKE_PR}" --repo "${REPO}" \
+  --json headRefOid --jq '.headRefOid')"
+[[ "${CURRENT_PR_HEAD_SHA}" == "${PR_HEAD_SHA}" ]]
+printf 'smoke_pr=%s enqueued_at=%s pr_head_sha=%s queue_head_sha=%s\n' \
+  "${SMOKE_PR}" "${ENQUEUED_AT}" "${PR_HEAD_SHA}" "${QUEUE_HEAD_SHA}"
+
+# Select only a newly-created merge_group run for this exact queue head. Do not
+# use the repository's latest merge-group run: it may belong to a different PR.
+RUN_JSON=""
+for attempt in {1..60}; do
+  RUN_JSON="$(gh api --method GET \
+    "repos/${REPO}/actions/workflows/_required.yml/runs" \
+    -f event=merge_group \
+    -f head_sha="${QUEUE_HEAD_SHA}" \
+    -f created=">=${ENQUEUED_AT}" \
+    -f per_page=100 \
+    | jq -c --arg queue_head_sha "${QUEUE_HEAD_SHA}" \
+      --arg enqueued_at "${ENQUEUED_AT}" '
+        [.workflow_runs[]
+         | select(
+             .event == "merge_group"
+             and .head_sha == $queue_head_sha
+             and .created_at >= $enqueued_at
+           )]
+        | sort_by(.created_at)
+        | first // empty
+      ')"
+  [[ -n "${RUN_JSON}" ]] && break
+  sleep 10
+done
+test -n "${RUN_JSON}"
+
+RUN_ID="$(jq -r '.id' <<<"${RUN_JSON}")"
+gh run watch "${RUN_ID}" --repo "${REPO}" --exit-status
+
+RUN_JSON="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}")"
+jq -e --arg queue_head_sha "${QUEUE_HEAD_SHA}" \
+  --arg enqueued_at "${ENQUEUED_AT}" '
+    .event == "merge_group"
+    and .head_sha == $queue_head_sha
+    and .created_at >= $enqueued_at
+    and .status == "completed"
+    and .conclusion == "success"
+  ' <<<"${RUN_JSON}"
+jq '{id,event,head_sha,created_at,status,conclusion,html_url}' \
+  <<<"${RUN_JSON}"
 
 EXPECTED="$(jq -c '.required_contexts | sort' "${POLICY}")"
-EMITTED="$(gh api --paginate \
-  "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-  | jq -s -c --argjson expected "${EXPECTED}" '
-      [.[].jobs[]
-       | select(.name as $name | $expected | index($name))
-       | .name]
-      | sort
-    ')"
-
-if [[ "${EMITTED}" != "${EXPECTED}" ]]; then
-  diff -u \
-    <(jq -r '.[]' <<<"${EXPECTED}") \
-    <(jq -r '.[]' <<<"${EMITTED}")
-  exit 1
-fi
+JOBS_JSON="$(mktemp)"
+CHECK_RUNS_JSON="$(mktemp)"
+trap 'rm -f "${JOBS_JSON}" "${CHECK_RUNS_JSON}"' EXIT
 
 gh api --paginate \
   "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-  | jq -s -e --argjson expected "${EXPECTED}" '
-      [.[].jobs[]
-       | select(.name as $name | $expected | index($name))
-       | select(.status != "completed" or .conclusion != "success")]
-      | length == 0
-    '
+  --jq '.jobs[]' | jq -s '.' > "${JOBS_JSON}"
+
+JOB_NAMES="$(jq -c --argjson expected "${EXPECTED}" '
+  [.[]
+   | select(.name as $name | $expected | index($name))
+   | .name]
+  | sort
+' "${JOBS_JSON}")"
+[[ "${JOB_NAMES}" == "${EXPECTED}" ]]
+
+jq -e --argjson expected "${EXPECTED}" \
+  --arg queue_head_sha "${QUEUE_HEAD_SHA}" '
+    [.[] | select(.name as $name | $expected | index($name))]
+    | all(.[];
+        .head_sha == $queue_head_sha
+        and .status == "completed"
+        and .conclusion == "success"
+      )
+  ' "${JOBS_JSON}"
+
+while IFS= read -r check_run_url; do
+  gh api "repos/${REPO}/check-runs/${check_run_url##*/}"
+done < <(jq -r --argjson expected "${EXPECTED}" '
+  .[]
+  | select(.name as $name | $expected | index($name))
+  | .check_run_url
+' "${JOBS_JSON}") | jq -s '.' > "${CHECK_RUNS_JSON}"
+
+CHECK_RUN_NAMES="$(jq -c '[.[].name] | sort' "${CHECK_RUNS_JSON}")"
+[[ "${CHECK_RUN_NAMES}" == "${EXPECTED}" ]]
+
+jq -e --arg queue_head_sha "${QUEUE_HEAD_SHA}" '
+  all(.[];
+    .head_sha == $queue_head_sha
+    and .status == "completed"
+    and .conclusion == "success"
+  )
+' "${CHECK_RUNS_JSON}"
 ```
 
-The job query intentionally compares the emitted required check-run names from
-that merge-group run with the 12-context artifact. Additional advisory jobs may
-run, but every policy context must appear exactly once and finish successfully.
+The selected run is tied to the designated smoke pull request through its merge
+queue entry, actual enqueue time, and exact queue head SHA. The job query then
+follows that run's `check_run_url` values. Both the required job names and their
+check-run names must equal the 12-context artifact exactly, without missing or
+duplicate required contexts, and every required job and check run must finish
+successfully. Additional advisory jobs may run but are not policy contexts.
 
 Do not remove or rename any required context during activation. The queue rule
 does not carry a separate check list; it relies on the existing

--- a/docs/ci/merge-queue.md
+++ b/docs/ci/merge-queue.md
@@ -1,0 +1,151 @@
+# Merge queue rollout
+
+Telemachy's `main` branch is prepared for a staged GitHub merge-queue rollout.
+The queue must not be activated until the readiness pull request has merged,
+strict review has passed, and a representative smoke-check pull request is ready.
+
+The repository-level `homeric-main-baseline` ruleset remains the source of truth
+for branch protection. Activation must append one `merge_queue` rule to that
+ruleset without changing its conditions, bypass actors, enforcement mode, or
+existing rules.
+
+## Required checks
+
+[`configs/github/merge-queue-policy.json`](../../configs/github/merge-queue-policy.json)
+is the machine-readable source of truth for the required contexts and approved
+queue rule. Inspect the exact context list with:
+
+```bash
+jq -r '.required_contexts[]' configs/github/merge-queue-policy.json
+```
+
+`.github/workflows/_required.yml` emits these contexts for `push`,
+`pull_request`, and `merge_group` `checks_requested` events. The tag-only
+`.github/workflows/release.yml` publisher must remain tag-only; it must never run
+for merge groups.
+
+## Approved policy
+
+The rule appended during activation must match the artifact's
+`merge_queue_rule` object exactly:
+
+```bash
+jq '.merge_queue_rule' configs/github/merge-queue-policy.json
+```
+
+This means at most 10 queue entries may request builds concurrently, at most 5
+entries may merge as a group, and a group may proceed with one entry after the
+5-minute wait. Required checks have 60 minutes to report. `ALLGREEN` requires
+every pull request represented in the group to satisfy the required checks.
+
+## Post-merge activation
+
+Activation is an operator step, not part of the readiness pull request.
+
+1. Confirm the readiness change is on `main` and its required checks are green.
+2. Confirm a representative pull request is ready to enter the queue.
+3. Re-read the live ruleset and save a restorable payload.
+4. Append only the approved `merge_queue` rule and update the full ruleset.
+5. Re-read the ruleset, then queue the smoke pull request with squash.
+6. Confirm a `merge_group` run emits and passes all required contexts before the
+   pull request merges.
+7. Record the ruleset response, workflow run, and queued merge in issue #308.
+
+The following commands preserve the full live ruleset and refuse to append a
+second queue rule. Review both generated JSON files before running the `PUT`.
+
+```bash
+REPO=HomericIntelligence/Telemachy
+POLICY=configs/github/merge-queue-policy.json
+RULESET_NAME=homeric-main-baseline
+RULESET_ID="$(gh api "repos/${REPO}/rulesets" \
+  --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")"
+test -n "${RULESET_ID}"
+
+gh api "repos/${REPO}/rulesets/${RULESET_ID}" \
+  | jq '{name, target, enforcement, bypass_actors, conditions, rules}' \
+  > /tmp/telemachy-ruleset-before.json
+
+jq -e '[.rules[] | select(.type == "merge_queue")] | length == 0' \
+  /tmp/telemachy-ruleset-before.json
+
+jq --slurpfile policy "${POLICY}" -e '
+  ([.rules[] | select(.type == "required_status_checks")
+    | .parameters.required_status_checks[].context] | sort)
+  == ($policy[0].required_contexts | sort)
+' /tmp/telemachy-ruleset-before.json
+
+jq --slurpfile policy "${POLICY}" \
+  '.rules += [$policy[0].merge_queue_rule]' \
+  /tmp/telemachy-ruleset-before.json \
+  > /tmp/telemachy-ruleset-with-queue.json
+
+gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" \
+  --input /tmp/telemachy-ruleset-with-queue.json
+```
+
+After the update, verify the live policy and run the smoke check:
+
+```bash
+gh api "repos/${REPO}/rulesets/${RULESET_ID}" \
+  | jq --slurpfile policy "${POLICY}" -e '
+      [.rules[] | select(.type == "merge_queue")]
+      == [$policy[0].merge_queue_rule]
+    '
+
+gh pr merge --auto --squash <SMOKE-PR> --repo "${REPO}"
+RUN_ID="$(gh run list --repo "${REPO}" --workflow _required.yml \
+  --event merge_group --limit 1 --json databaseId,event \
+  --jq 'map(select(.event == "merge_group"))[0].databaseId')"
+test -n "${RUN_ID}"
+
+gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+  --jq '{id,event,head_sha,status,conclusion,html_url}'
+
+EXPECTED="$(jq -c '.required_contexts | sort' "${POLICY}")"
+EMITTED="$(gh api --paginate \
+  "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+  | jq -s -c --argjson expected "${EXPECTED}" '
+      [.[].jobs[]
+       | select(.name as $name | $expected | index($name))
+       | .name]
+      | sort
+    ')"
+
+if [[ "${EMITTED}" != "${EXPECTED}" ]]; then
+  diff -u \
+    <(jq -r '.[]' <<<"${EXPECTED}") \
+    <(jq -r '.[]' <<<"${EMITTED}")
+  exit 1
+fi
+
+gh api --paginate \
+  "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+  | jq -s -e --argjson expected "${EXPECTED}" '
+      [.[].jobs[]
+       | select(.name as $name | $expected | index($name))
+       | select(.status != "completed" or .conclusion != "success")]
+      | length == 0
+    '
+```
+
+The job query intentionally compares the emitted required check-run names from
+that merge-group run with the 12-context artifact. Additional advisory jobs may
+run, but every policy context must appear exactly once and finish successfully.
+
+Do not remove or rename any required context during activation. The queue rule
+does not carry a separate check list; it relies on the existing
+`required_status_checks` rule in the same ruleset.
+
+## Rollback
+
+If the rule update does not preserve the ruleset or the smoke check cannot emit
+all required contexts, stop the rollout and restore the reviewed snapshot:
+
+```bash
+gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" \
+  --input /tmp/telemachy-ruleset-before.json
+```
+
+Re-read the ruleset after rollback and confirm the `merge_queue` rule is absent
+while all pre-existing required contexts and protection rules remain intact.

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -36,6 +36,9 @@ documentation change in Telemachy. It complements `CONTRIBUTING.md`.
 - [ ] Workflow runs successfully on the PR.
 - [ ] Required check list in branch protection updated if a job was
       renamed/added.
+- [ ] Required-check workflow changes pass `tests/test_merge_queue.py` and
+      preserve the staged activation contract in
+      [`docs/ci/merge-queue.md`](ci/merge-queue.md).
 - [ ] Time and resource impact noted in the PR description.
 
 ## Not done

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -1,0 +1,104 @@
+"""Regression tests for GitHub merge-queue readiness."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
+RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
+MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
+
+EXPECTED_REQUIRED_CONTEXTS = [
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "package",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+]
+
+EXPECTED_MERGE_QUEUE_RULE = {
+    "type": "merge_queue",
+    "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+    },
+}
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict), f"{path} must contain a workflow mapping"
+    return data
+
+
+def _on_block(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the Actions trigger block despite PyYAML's YAML 1.1 `on` coercion."""
+    on_block = workflow.get(True, workflow.get("on"))
+    assert isinstance(on_block, dict), "workflow `on` block must be a mapping"
+    return on_block
+
+
+def _load_policy() -> dict[str, Any]:
+    policy = json.loads(MERGE_QUEUE_POLICY.read_text())
+    assert isinstance(policy, dict), "merge-queue policy must be a JSON object"
+    return policy
+
+
+def test_policy_artifact_pins_exact_required_contexts() -> None:
+    assert _load_policy()["required_contexts"] == EXPECTED_REQUIRED_CONTEXTS
+
+
+def test_policy_artifact_pins_exact_approved_queue_rule() -> None:
+    assert _load_policy()["merge_queue_rule"] == EXPECTED_MERGE_QUEUE_RULE
+
+
+def test_required_workflow_push_main_block_is_exact() -> None:
+    on_block = _on_block(_load_workflow(REQUIRED_WORKFLOW))
+    assert on_block["push"] == {"branches": ["main"]}
+
+
+def test_required_workflow_pull_request_main_block_is_exact() -> None:
+    on_block = _on_block(_load_workflow(REQUIRED_WORKFLOW))
+    assert on_block["pull_request"] == {"branches": ["main"]}
+
+
+def test_required_workflow_merge_group_block_is_exact() -> None:
+    on_block = _on_block(_load_workflow(REQUIRED_WORKFLOW))
+    assert on_block["merge_group"] == {"types": ["checks_requested"]}
+
+
+def test_required_workflow_emits_every_policy_context_exactly_once() -> None:
+    jobs = _load_workflow(REQUIRED_WORKFLOW)["jobs"]
+    emitted_names = [
+        job.get("name", job_id) for job_id, job in jobs.items() if isinstance(job, dict)
+    ]
+    policy_contexts = _load_policy()["required_contexts"]
+
+    emitted_policy_contexts = [name for name in emitted_names if name in policy_contexts]
+
+    assert sorted(emitted_policy_contexts) == policy_contexts
+    assert len(emitted_policy_contexts) == len(set(emitted_policy_contexts))
+
+
+def test_release_publisher_remains_tag_only() -> None:
+    on_block = _on_block(_load_workflow(RELEASE_WORKFLOW))
+
+    assert on_block["push"] == {"tags": ["v*.*.*"]}
+    assert "pull_request" not in on_block
+    assert "merge_group" not in on_block

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -11,6 +11,7 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
 RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
 MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
+MERGE_QUEUE_RUNBOOK = REPO_ROOT / "docs" / "ci" / "merge-queue.md"
 
 EXPECTED_REQUIRED_CONTEXTS = [
     "build",
@@ -60,6 +61,18 @@ def _load_policy() -> dict[str, Any]:
     return policy
 
 
+def _job(workflow: dict[str, Any], job_id: str) -> dict[str, Any]:
+    job = workflow["jobs"][job_id]
+    assert isinstance(job, dict), f"workflow job {job_id!r} must be a mapping"
+    return job
+
+
+def _step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    step = next(item for item in job["steps"] if item.get("name") == name)
+    assert isinstance(step, dict), f"workflow step {name!r} must be a mapping"
+    return step
+
+
 def test_policy_artifact_pins_exact_required_contexts() -> None:
     assert _load_policy()["required_contexts"] == EXPECTED_REQUIRED_CONTEXTS
 
@@ -94,6 +107,64 @@ def test_required_workflow_emits_every_policy_context_exactly_once() -> None:
 
     assert sorted(emitted_policy_contexts) == policy_contexts
     assert len(emitted_policy_contexts) == len(set(emitted_policy_contexts))
+
+
+def test_required_gitleaks_scan_fails_on_detected_secrets() -> None:
+    workflow = _load_workflow(REQUIRED_WORKFLOW)
+    scan = _step(_job(workflow, "security-secrets-scan"), "Run Gitleaks")["run"]
+
+    assert "--report-format sarif" in scan
+    assert "--report-path gitleaks.sarif" in scan
+    assert "--exit-code 0" not in scan
+
+
+def test_required_gitleaks_sarif_upload_runs_after_scan_failure() -> None:
+    workflow = _load_workflow(REQUIRED_WORKFLOW)
+    upload = _step(_job(workflow, "security-secrets-scan"), "Upload Gitleaks SARIF")
+
+    assert upload["if"] == "always() && hashFiles('gitleaks.sarif') != ''"
+
+
+def test_smoke_runbook_correlates_new_run_to_smoke_pr_queue_head() -> None:
+    runbook = MERGE_QUEUE_RUNBOOK.read_text()
+
+    for marker in (
+        "SMOKE_PR=",
+        "PR_HEAD_SHA=",
+        "ENQUEUED_AT=",
+        "QUEUE_HEAD_SHA=",
+        "event=merge_group",
+        'head_sha="${QUEUE_HEAD_SHA}"',
+        'created=">=${ENQUEUED_AT}"',
+    ):
+        assert marker in runbook
+    assert "--limit 1" not in runbook
+
+
+def test_smoke_runbook_verifies_selected_run_terminal_result() -> None:
+    runbook = MERGE_QUEUE_RUNBOOK.read_text()
+
+    for assertion in (
+        '.event == "merge_group"',
+        ".head_sha == $queue_head_sha",
+        '.status == "completed"',
+        '.conclusion == "success"',
+    ):
+        assert assertion in runbook
+
+
+def test_smoke_runbook_compares_exact_job_and_check_run_names_to_policy() -> None:
+    runbook = MERGE_QUEUE_RUNBOOK.read_text()
+
+    assert 'EXPECTED="$(jq -c \'.required_contexts | sort\' "${POLICY}")"' in runbook
+    assert "actions/runs/${RUN_ID}/jobs?per_page=100" in runbook
+    assert ".check_run_url" in runbook
+    assert 'CHECK_RUN_NAMES="' in runbook
+    assert '[[ "${JOB_NAMES}" == "${EXPECTED}" ]]' in runbook
+    assert '[[ "${CHECK_RUN_NAMES}" == "${EXPECTED}" ]]' in runbook
+    assert "all(.;" not in runbook
+    assert runbook.count("all(.[];") == 2
+    assert "repos/${REPO}/check-runs/${check_run_url##*/}" in runbook
 
 
 def test_release_publisher_remains_tag_only() -> None:


### PR DESCRIPTION
## Summary

- enable the required-check workflow for `merge_group` / `checks_requested`
  while preserving the exact `push.main` and `pull_request.main` triggers
- add `configs/github/merge-queue-policy.json` as the machine-readable source
  of truth for the 12 required contexts and approved queue parameters
- validate the artifact from focused tests and consume it in activation and
  merge-group smoke commands
- keep the release publisher tag-only and make no live ruleset change

Refs #308

Umbrella rollout: https://github.com/HomericIntelligence/Odysseus/issues/386

Replaces #309 because its only commit did not contain a DCO `Signed-off-by`
trailer.

## Strict-review remediations

- the policy test validates exact required contexts and the exact `merge_queue`
  rule object instead of parsing Markdown prose
- independent tests pin the exact `push.main`, `pull_request.main`, and
  `merge_group/checks_requested` blocks
- the runbook derives the activation payload and required-context guard from
  the policy artifact
- the smoke procedure queries the selected merge-group run's jobs, compares
  emitted required names exactly against the 12-context artifact, and requires
  each to complete successfully
- activation and queued smoke evidence remain post-merge operator work;
  independent human workflow review is required before merge

## Live baseline preserved

- default branch: `main`
- active ruleset: `homeric-main-baseline` (repository ruleset `15556487`)
- required contexts: `lint`, `unit-tests`, `integration-tests`,
  `security/dependency-scan`, `security/secrets-scan`, `build`,
  `schema-validation`, `deps/version-sync`, `test`, `package`, `install`, and
  `release`
- no ruleset mutation, protection weakening, secret, ADR, or submodule change
  is included

## Verification

- TDD RED: `pixi run pytest tests/test_merge_queue.py -q` — 3 failed, 4 passed
  because the policy artifact was absent
- focused GREEN: `pixi run pytest tests/test_merge_queue.py -q` — 7 passed
- `just check` — Ruff passed; mypy passed for 17 source files; Bandit found 0
  medium/high issues; 290 passed, 3 skipped
- coverage: 290 passed, 3 skipped; 88.86% (75% required)
- changed-file pre-commit hooks — all applicable hooks passed
- markdownlint-cli2 v0.20.0 — 0 errors across the three changed Markdown files
- yamllint — exit 0 with seven pre-existing line-length warnings
- GitHub workflow JSON Schema validation — `ok -- validation done`
- `just validate workflows/example.yaml` — `Valid. Workflow: codebase-audit`
- `git diff --check` — clean
- GitHub commit verification for `65c97ec2920ba89c9440edf00ea32a2b697ab608`
  — verified signature, valid reason, and matching `Signed-off-by` trailer

A repo-wide Ruff format check reports 14 pre-existing files outside this
six-file diff; the changed Python test passes the scoped format check. Pytest
exits 0 and prints the known post-summary OpenTelemetry closed-stream warning.

## Risk and rollout

- backwards compatible: yes
- schema bump: not required
- CI impact: the existing required-check job set runs for merge groups; no
  required context is added, removed, or renamed
- post-merge: a human operator must review the generated ruleset payload,
  activate the queue, run the representative queued smoke cycle, and record
  evidence in issue #308
