### PR TITLE
ci: fast (<5 min) merge-queue smoke check

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.ref }}

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,45 @@
+name: Merge Queue Smoke
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Validate GitHub Actions workflow YAML against JSON schema
+        # Same gate class as the required schema-validation job, but using the
+        # vendored schema bundled with check-jsonschema so the merge gate has
+        # no schemastore.org network dependency.
+        run: |
+          set -euo pipefail
+          pip install check-jsonschema PyYAML pytest --quiet
+          find .github/workflows -name "*.yml" -print0 | \
+            xargs -0 check-jsonschema --builtin-schema vendor.github-workflows
+
+      - name: Lint YAML
+        run: |
+          set -euo pipefail
+          pip install yamllint --quiet
+          yamllint -c .yamllint.yaml .
+
+      - name: Merge-queue readiness regression tests
+        # --noconftest: run the self-contained workflow-contract suite without
+        # loading tests/conftest.py, which imports the full telemachy package
+        # (pixi-managed runtime deps the smoke gate does not install).
+        run: python3 -m pytest --noconftest -p no:cacheprovider tests/test_merge_queue.py -q
+
+      - name: Run symlink check
+        run: bash scripts/check-symlinks.sh

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 REQUIRED_WORKFLOW = WORKFLOWS_DIR / "_required.yml"
 RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
+SMOKE_WORKFLOW = WORKFLOWS_DIR / "merge-queue-smoke.yml"
 MERGE_QUEUE_POLICY = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
 MERGE_QUEUE_RUNBOOK = REPO_ROOT / "docs" / "ci" / "merge-queue.md"
 
@@ -91,9 +92,21 @@ def test_required_workflow_pull_request_main_block_is_exact() -> None:
     assert on_block["pull_request"] == {"branches": ["main"]}
 
 
-def test_required_workflow_merge_group_block_is_exact() -> None:
+def test_required_workflow_no_longer_runs_on_merge_group() -> None:
     on_block = _on_block(_load_workflow(REQUIRED_WORKFLOW))
-    assert on_block["merge_group"] == {"types": ["checks_requested"]}
+    assert "merge_group" not in on_block
+
+
+def test_smoke_workflow_handles_merge_group_checks_requested_only() -> None:
+    on_block = _on_block(_load_workflow(SMOKE_WORKFLOW))
+    assert on_block == {"merge_group": {"types": ["checks_requested"]}}
+
+
+def test_smoke_workflow_runs_exactly_one_fast_smoke_job() -> None:
+    jobs = _load_workflow(SMOKE_WORKFLOW)["jobs"]
+    assert list(jobs) == ["merge-queue-smoke"]
+    assert jobs["merge-queue-smoke"]["name"] == "merge-queue-smoke"
+    assert jobs["merge-queue-smoke"]["timeout-minutes"] == 5
 
 
 def test_required_workflow_emits_every_policy_context_exactly_once() -> None:


### PR DESCRIPTION
## Diagnosis

Merge-queue (`merge_group`) runs re-execute the full required workflow — 18 jobs counting matrix legs — and each job waits 8–16+ minutes for a runner slot. Total wall time per queued merge: 70–90 minutes, for code that already passed the identical checks on the pull request minutes earlier.

## Design

- `_required.yml` no longer triggers on `merge_group`. PR-side CI is otherwise completely untouched — no jobs added, removed, or changed; `pull_request` and `push: main` behavior is byte-identical to main.
- A new `.github/workflows/merge-queue-smoke.yml` triggers ONLY on `merge_group` and runs a single job named `merge-queue-smoke` (one runner slot, `timeout-minutes: 5`) with real fast validation borrowed from the repo's existing quick jobs: GitHub-workflow JSON-schema validation (vendored schema, network-free), `yamllint -c .yamllint.yaml .`, the merge-queue readiness pytest suite (`--noconftest`), and the symlink check. No `continue-on-error`, no `|| true`.
- Exactly one `merge-queue-smoke` check run exists per merge_group event; the full suites no longer run in the queue.
- `tests/test_merge_queue.py` (run by the required `unit-tests` job) pinned the old trigger contract, so it was minimally updated: `_required.yml` must have no `merge_group` trigger, and `merge-queue-smoke.yml` must handle `merge_group`/`checks_requested` with exactly one fast `merge-queue-smoke` job.

## Post-merge ruleset rollout (REQUIRED — read before using the queue)

After merge, replace ALL `required_status_checks` contexts (in every ruleset, including the extras rulesets) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running but become non-blocking; the queue must not be used between merge and flip (the old contexts are no longer produced on `merge_group` and every queue entry would time out and fail). At flip time, `configs/github/merge-queue-policy.json` and the `EXPECTED_REQUIRED_CONTEXTS` pin in `tests/test_merge_queue.py` should be updated to match the new required-context list.

DO NOT MERGE until the flip is scheduled. No rulesets were modified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
