### PR TITLE
ci(codeql): add fleet-standard CodeQL analysis (python)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+# CodeQL configuration for Telemachy.
+#
+# Scope CodeQL analysis to first-party source. Build artifacts, vendored
+# dependencies, and generated trees are third-party code we do not maintain,
+# so their findings must not be reported against this repo.
+#
+# Part of the fleet-wide security coverage rollout (HomericIntelligence/Odysseus#455).
+name: "Telemachy CodeQL config"
+
+paths-ignore:
+  - build/**
+  - "**/_deps/**"
+  - "**/node_modules/**"
+  - "**/.venv/**"
+  - dist/**
+  - vendor/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL / python
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          languages: python
+          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          category: "/language:python"


### PR DESCRIPTION
Enables CodeQL code scanning on this repo (currently only SARIF uploads from Trivy/gitleaks, no CodeQL analysis).

- `.github/workflows/codeql.yml`: python analysis on push to main, PRs, and a weekly schedule; `security-extended` + `security-and-quality` queries.
- `.github/codeql/codeql-config.yml`: paths-ignore for build/vendored/generated trees.

Part of the fleet-wide security coverage rollout (HomericIntelligence/Odysseus#455).