### PR TITLE
fix(codeql): clear py notes across src + tests

### DIFF
--- a/src/telemachy/audit.py
+++ b/src/telemachy/audit.py
@@ -28,10 +28,10 @@ class AuditSinkProtocol(Protocol):
     """Protocol for audit sinks — dependency-injected into WorkflowExecutor."""
 
     def emit(self, event_type: str, *, workflow_id: str | None = None, **fields: Any) -> None:
-        ...
+        """Emit one audit event."""
 
     def close(self) -> None:
-        ...
+        """Close the sink."""
 
 
 class NullSink:

--- a/src/telemachy/cli.py
+++ b/src/telemachy/cli.py
@@ -289,8 +289,11 @@ def run(
                     result = await executor.execute(spec, workflow_id=workflow_id)
                 finally:
                     watcher.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await watcher
+                    # Re-await the cancelled watcher so it can run its
+                    # cancellation cleanup (raised CancelledError is expected).
+                    if watcher is not None:
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await watcher
                     store.clear_cancel(workflow_id)
 
         if result.status == "completed":

--- a/src/telemachy/mcp_server.py
+++ b/src/telemachy/mcp_server.py
@@ -17,17 +17,6 @@ from typing import Any
 from telemachy.agamemnon_client import AgamemnonClient
 from telemachy.config import settings
 
-# Recorded in step 1's spike gate (see implementation_order). Updated to match
-# the installed `mcp` SDK before `build_server()` is wired in step 4.
-_SDK_API_NOTES = """
-mcp SDK 1.x API used by build_server():
-- mcp.server.Server(name) — server factory
-- @server.list_tools() decorator on async () -> list[Tool]
-- @server.call_tool() decorator on async (name, arguments) -> list[TextContent]
-- mcp.server.stdio.stdio_server() — async context yielding (read, write) streams
-- mcp.types.Tool, mcp.types.TextContent — return types
-"""
-
 
 @dataclass
 class _ToolDescriptor:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,8 +18,6 @@ from telemachy.models import WorkflowSpec
 _TEAM_TASKS_RE = re.compile(r"^/v1/teams/(?P<tid>[^/]+)/tasks$")
 _TEAM_TASK_RE = re.compile(r"^/v1/teams/(?P<tid>[^/]+)/tasks/(?P<task_id>[^/]+)$")
 _TEAM_MEMBERS_RE = re.compile(r"^/v1/teams/(?P<tid>[^/]+)$")
-_AGENT_START_RE = re.compile(r"^/v1/agents/(?P<aid>[^/]+)/start$")
-_AGENT_STOP_RE = re.compile(r"^/v1/agents/(?P<aid>[^/]+)/stop$")
 _AGENT_DELETE_RE = re.compile(r"^/v1/agents/(?P<aid>[^/]+)$")
 
 

--- a/tests/test_nats_monitor.py
+++ b/tests/test_nats_monitor.py
@@ -106,6 +106,7 @@ class TestNatsMonitorBasics:
         await asyncio.wait_for(wait_done.wait(), timeout=1.0)
 
         task.cancel()
+        # Re-await the cancelled task so its cancellation cleanup runs.
         with contextlib.suppress(asyncio.CancelledError):
             await task
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,6 +9,7 @@ import pytest
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
+import telemachy.telemetry as telemetry_mod
 from telemachy.telemetry import (
     WORKFLOWS_STARTED,
     JsonFormatter,
@@ -172,10 +173,9 @@ def test_json_formatter_safe_without_filter() -> None:
 @pytest.fixture(autouse=True)
 def reset_metrics_state() -> None:
     """Reset metrics state between tests."""
-    import telemachy.telemetry
 
-    telemachy.telemetry._metrics_started = False
-    telemachy.telemetry._tracing_started = False
+    telemetry_mod._metrics_started = False
+    telemetry_mod._tracing_started = False
 
 
 def test_setup_metrics_idempotent() -> None:


### PR DESCRIPTION
Telemachy CodeQL sweep:

- Protocol method ellipsis bodies → docstrings (py/ineffectual-statement x4).
- Cancelled-task re-await pattern in cli.py + test_nats_monitor.py.
- Unused regexes in integration conftest + stale `_SDK_API_NOTES` block removed (py/unused-*).
- Import style consolidated (py/import-and-import-from).

Local: 297 tests pass (pre-existing ConsoleSpanExporter closed-file crash unrelated).