### PR TITLE
ci(security): grant security-events write for SARIF upload jobs

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -249,6 +249,9 @@ jobs:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write  # trivy SARIF upload needs code-scanning write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -273,6 +276,9 @@ jobs:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write  # gitleaks SARIF upload needs code-scanning write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:


### PR DESCRIPTION
Grants security-events write to the secrets-scan and dependency-scan SARIF upload jobs in _required.yml. Without it, codeql-action/upload-sarif fails with "Resource not accessible by integration", which is currently blocking main (Required Checks).
